### PR TITLE
Local refinement example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ bin_gcc/
 bin_gcc_release/
 doc/doxygen/html
 Build/
+build/

--- a/examples/refinement/CMakeLists.txt
+++ b/examples/refinement/CMakeLists.txt
@@ -14,8 +14,18 @@ target_link_libraries(lf.examples.refinement.refinement_demo
 
 target_compile_features(lf.examples.refinement.refinement_demo PUBLIC cxx_std_17)
 
-  
-    
 
-  
+set(point_refinement_demo point_refinement_demo.cc)
+
+add_executable(lf.examples.refinement.point_refinement_demo ${point_refinement_demo})
+
+target_link_libraries(lf.examples.refinement.point_refinement_demo
+  PUBLIC Eigen3::Eigen Boost::boost
+  lf.mesh
+  lf.mesh.test_utils
+  lf.mesh.utils
+  lf.mesh.hybrid2dp
+  lf.refinement )
+
+target_compile_features(lf.examples.refinement.point_refinement_demo PUBLIC cxx_std_17)
 

--- a/examples/refinement/point_refinement_demo.cc
+++ b/examples/refinement/point_refinement_demo.cc
@@ -1,0 +1,143 @@
+/**
+ * @file point_refinement_demo.cc
+ * @brief example code for building and pointwise refining of a tensor product
+ *        mesh
+ *
+ * This code generates a tensor-product mesh and performs a user specified
+ * number of steps of pointwise uniform refinement on the cell containing the
+ * point (0.5, 0.5).
+ *
+ * In the end the information about all meshes created in the process
+ * is stored in the form of MATLAB functions.
+ */
+
+#include <iostream>
+
+#include <lf/refinement/mesh_hierarchy.h>
+#include <lf/refinement/refutils.h>
+#include "lf/base/base.h"
+#include "lf/mesh/hybrid2dp/hybrid2dp.h"
+#include "lf/mesh/test_utils/check_mesh_completeness.h"
+#include "lf/mesh/test_utils/test_meshes.h"
+#include "lf/mesh/utils/utils.h"
+
+
+int main(int argc, const char *argv[]) {
+    using size_type = lf::base::size_type;
+    using lf::mesh::utils::TikzOutputCtrl;
+
+    std::shared_ptr<lf::mesh::hybrid2dp::MeshFactory> mesh_factory_ptr =
+        std::make_shared<lf::mesh::hybrid2dp::MeshFactory>(2);
+
+    // Build single-cell tensor product mesh on unit square
+    lf::mesh::hybrid2d::TPQuadMeshBuilder builder(mesh_factory_ptr);
+    builder.setBottomLeftCorner(Eigen::Vector2d{0,0});
+    builder.setTopRightCorner(Eigen::Vector2d{1,1});
+    builder.setNoXCells(1);
+    builder.setNoYCells(1);
+    std::shared_ptr<lf::mesh::Mesh> mesh_ptr = builder.Build();
+
+    // Output mesh information
+    const lf::mesh::Mesh &mesh = *mesh_ptr;
+    lf::mesh::utils::PrintInfo(mesh, std::cout);
+    std::cout << std::endl;
+
+    // Build mesh hierarchy
+    lf::refinement::MeshHierarchy multi_mesh(mesh_ptr, mesh_factory_ptr);
+
+    // Mark cell containing point (0.5, 0.5) which should be refined
+    auto marker = [] (const lf::mesh::Mesh &mesh, const lf::mesh::Entity &edge) {
+        Eigen::MatrixXd ref_a(2, 1);
+        Eigen::MatrixXd ref_b(2, 1);
+        Eigen::MatrixXd ref_c(2, 1);
+        Eigen::MatrixXd ref_d(2, 1);
+        ref_a << 0,0;
+        ref_b << 1,0;
+        ref_c << 1,1;
+        ref_d << 0,1;
+
+        Eigen::MatrixXd point(2,1);
+        point << .5,.5;
+
+        for (const lf::mesh::Entity &cell : mesh.Entities(0)) {
+            auto geom = cell.Geometry();
+
+            // Due to refinement we have to make sure that the global
+            // coordinates are always ordered in the same way:
+            // c ---- d
+            //   |  |
+            // a ---- b 
+            std::vector<Eigen::MatrixXd> glob_coords = {geom->Global(ref_a), 
+                geom->Global(ref_b), geom->Global(ref_c), geom->Global(ref_d)};
+
+            auto coord_sort = [] (Eigen::MatrixXd x, Eigen::MatrixXd y) {
+                return (x(1,0) < y(1,0)) || 
+                       ((x(1,0) == y(1,0)) && (x(0,0) <= y(0,0)));
+            };
+            std::sort(glob_coords.begin(), glob_coords.end(), coord_sort);
+
+            Eigen::MatrixXd glob_a = glob_coords[0];
+            Eigen::MatrixXd glob_b = glob_coords[1];
+            Eigen::MatrixXd glob_c = glob_coords[2];
+            Eigen::MatrixXd glob_d = glob_coords[3];
+
+            // Check if point lies inside cell
+            if (glob_a(0,0) <= point(0,0) && glob_a(1,0) <= point(1,0) &&
+                glob_b(0,0) >= point(0,0) && glob_b(1,0) <= point(1,0) &&
+                glob_c(0,0) <= point(0,0) && glob_c(1,0) >= point(1,0) &&
+                glob_d(0,0) >= point(0,0) && glob_d(1,0) >= point(1,0)) {
+
+                // Check if cell contains edge
+                auto edges = cell.SubEntities(1);
+                if (edges.end() != std::find(edges.begin(), edges.end(), edge))
+                    return true;
+            }
+        }
+        return false;
+    };
+
+    std::cout << "refinement steps: ";
+    size_t refinement_steps;
+    std::cin >> refinement_steps;
+
+    std::cout << "pointwise refinement [0/1]: ";
+    bool point_refinement;
+    std::cin >> point_refinement;
+    std::cout << std::endl;
+
+    for (int step = 0; step < refinement_steps; ++step) {
+        // Obtain pointer to mesh on finest level
+        const size_type n_levels = multi_mesh.NumLevels();
+        std::shared_ptr<const lf::mesh::Mesh> mesh_fine =
+            multi_mesh.getMesh(n_levels - 1);
+
+        // Print number of entities of various co-dimensions
+        std::cout << "Mesh on level " << n_levels - 1 << ": " 
+            << mesh_fine->Size(2)<< " nodes, " 
+            << mesh_fine->Size(1) << " edges, " 
+            << mesh_fine->Size(0) << " cells," << std::endl;
+
+        lf::mesh::utils::writeTikZ(
+                *mesh_fine, 
+                std::string("refinement_mesh") + std::to_string(step) + ".txt",
+                TikzOutputCtrl::RenderCells | TikzOutputCtrl::CellNumbering |
+                TikzOutputCtrl::VerticeNumbering | 
+                TikzOutputCtrl::NodeNumbering | TikzOutputCtrl::EdgeNumbering);
+
+        if (point_refinement) {
+            multi_mesh.MarkEdges(marker);
+            multi_mesh.RefineMarked();
+        } else {
+            multi_mesh.RefineRegular();
+        }
+    }
+
+    // Generate  MATLAB functions that provide a description of all
+    // levels of the mesh hierarchy
+    std::cout << std::endl << "basename for MATLAB output: ";
+    std::string basename;
+    std::cin >> basename;
+    lf::refinement::WriteMatlab(multi_mesh, basename);
+
+    return 0;
+}

--- a/examples/refinement/refinement_demo.cc
+++ b/examples/refinement/refinement_demo.cc
@@ -37,7 +37,7 @@ int main(int argc, const char *argv[]) {
   // Set control variables from command line or file "setup vars"
   lf::base::ReadCtrVarsCmdArgs(argc, argv);
   if (!lf::base::ReadCtrlVarsFile("setup.vars")) {
-    std::cout << "No file specifyng control variables" << std::endl;
+    std::cout << "No file specifying control variables" << std::endl;
   }
   std::cout << "##### Control variables:" << std::endl;
   lf::base::ListCtrlVars(std::cout);
@@ -125,7 +125,7 @@ int main(int argc, const char *argv[]) {
         multi_mesh.getMesh(n_levels - 1);
     // Print number of entities of various co-dimensions
     std::cout << "#### Mesh on level " << n_levels - 1 << ": " << mesh->Size(2)
-              << " nodes, " << mesh->Size(1) << " nodes, " << mesh->Size(0)
+              << " nodes, " << mesh->Size(1) << " edges, " << mesh->Size(0)
               << " cells," << std::endl;
     std::stringstream level_asc;
     level_asc << refstep;


### PR DESCRIPTION
A couple of remarks regarding this lengthy and inefficient implementation:

- I looked for a method similar to BETL's `intersection.inside()`, but couldn't find it. Thus we have to loop through all cells every time we are checking whether to mark an edge or not. With `intersection.inside()` we could just omit this loop. @hiptmair do you think this will be implemented in the future?
- Similarly, we couldn't find a method similar to BETL's `geometry.mapCorner(int i)`. This would allow us to remove lines 50-57. @hiptmair implementation should be straightforward, should I do it?
- The tikz exporter is a good idea, but not very practical (maybe I'm also using it wrong). I always have to copy the output into a LaTeX document, run pdflatex and then open the PDF, which is very tedious if one is looking at 5 different refined meshes. I looked for a tikz-to-matplotlib package, but couldn't find any. Also, I don't have MATLAB installed on my computer. Since it is extremely beneficial to be able to easily visualize the mesh, I would suggest that we provide an exporter which saves the data in a matplotlib-friendly format. @hiptmair should I try to write such an exporter?