### PR TITLE
Fixed errors for documentation of lf::mesh classes

### DIFF
--- a/lib/lf/geometry/geometry_interface.h
+++ b/lib/lf/geometry/geometry_interface.h
@@ -151,7 +151,7 @@ class Geometry {
   /**
    * @brief element shape by affine mapping from reference element
    *
-   * @retrurn true, if the element is the affine image of a reference element
+   * @return true, if the element is the affine image of a reference element
    *
    * An affine map is a linear mapping plus a translation. For a 2D mesh
    * an entity has an affine geometry, if

--- a/lib/lf/geometry/print_info.h
+++ b/lib/lf/geometry/print_info.h
@@ -24,7 +24,7 @@ void PrintInfo(const Geometry& geom, std::ostream& o);
  * @brief Operator overload to print a `Geometry` to a stream, such as
  * `std::cout`
  * @param stream The stream to which this function should output
- * @param entity The geometry to write to `stream`.
+ * @param geom The geometry to write to `stream`.
  * @return The stream itself.
  *
  * - If Geometry::output_ctrl_ == 0, type reference element of geometry is sent

--- a/lib/lf/mesh/hybrid2d/mesh_factory.h
+++ b/lib/lf/mesh/hybrid2d/mesh_factory.h
@@ -24,24 +24,24 @@ class MeshFactory : public mesh::MeshFactory {
   explicit MeshFactory(dim_t dim_world)
       : dim_world_(dim_world), built_(false) {}
 
-  /** @copydoc MeshFactory::DimWorld() */
+  /** @copydoc Mesh::DimWorld() */
   dim_t DimWorld() const override { return dim_world_; }
 
   /** @copydoc Mesh::DimMesh() */
   dim_t DimMesh() const override { return 2; }
 
-  /** @copydoc MeshFactory::AddPoint() */
+  /** @copydoc Mesh::AddPoint() */
   size_type AddPoint(coord_t coord) override;
 
-  /** @copydoc MeshFactory::AddPoint() */
+  /** @copydoc Mesh::AddPoint() */
   size_type AddPoint(std::unique_ptr<geometry::Geometry>&& geometry) override;
 
-  /** @copydoc MeshFactory::AddEntity() */
+  /** @copydoc Mesh::AddEntity() */
   size_type AddEntity(base::RefEl ref_el,
                       const base::ForwardRange<const size_type>& nodes,
                       std::unique_ptr<geometry::Geometry>&& geometry) override;
 
-  /** @copydoc MeshFactory::Build() */
+  /** @copydoc Mesh::Build() */
   std::shared_ptr<mesh::Mesh> Build() override;
 
  private:

--- a/lib/lf/mesh/hybrid2dp/mesh.h
+++ b/lib/lf/mesh/hybrid2dp/mesh.h
@@ -97,7 +97,7 @@ class Mesh : public mesh::Mesh {
 /**
  * @brief Operator overload to print a `Mesh` to a stream, such as `std::cout`
  * @param stream The stream to which this function should output
- * @param mesh The mesh to write to `stream`.
+ * @param Mesh& The mesh to write to `stream`.
  * @return The stream itself.
  *
  */

--- a/lib/lf/mesh/hybrid2dp/mesh_factory.h
+++ b/lib/lf/mesh/hybrid2dp/mesh_factory.h
@@ -34,24 +34,24 @@ class MeshFactory : public mesh::MeshFactory {
    */
   explicit MeshFactory(dim_t dim_world) : dim_world_(dim_world) {}
 
-  /** @copydoc MeshFactory::DimWorld() */
+  /** @copydoc Mesh::DimWorld() */
   dim_t DimWorld() const override { return dim_world_; }
 
   /** @copydoc Mesh::DimMesh() */
   dim_t DimMesh() const override { return 2; }
 
-  /** @copydoc MeshFactory::AddPoint() */
+  /** @copydoc Mesh::AddPoint() */
   size_type AddPoint(coord_t coord) override;
 
-  /** @copydoc MeshFactory::AddPoint() */
+  /** @copydoc Mesh::AddPoint() */
   size_type AddPoint(std::unique_ptr<geometry::Geometry>&& geometry) override;
 
-  /** @copydoc MeshFactory::AddEntity() */
+  /** @copydoc Mesh::AddEntity() */
   size_type AddEntity(base::RefEl ref_el,
                       const base::ForwardRange<const size_type>& nodes,
                       std::unique_ptr<geometry::Geometry>&& geometry) override;
 
-  /** @copydoc MeshFactory::Build() */
+  /** @copydoc Mesh::Build() */
   std::shared_ptr<mesh::Mesh> Build() override;
 
   /** @brief output function printing asssembled lists of entity information */

--- a/lib/lf/mesh/mesh_factory.h
+++ b/lib/lf/mesh/mesh_factory.h
@@ -20,7 +20,7 @@ class MeshFactory {
   /** @copydoc Mesh::size_type */
   using size_type = unsigned int;
 
-  /** @copydoc Geometry::coord_t */
+  /** @copydoc Mesh::coord_t */
   using coord_t = Eigen::VectorXd;
 
   using dim_t = unsigned char;


### PR DESCRIPTION
Fixed (among others) the following doxygen errors:

lehrfempp/lib/lf/mesh/hybrid2dp/mesh.h:98: warning: argument 'mesh' of command @param is not found in the argument list of lf::mesh::hybrid2dp::operator<<(std::ostream &stream, const Mesh &)

lehrfempp/lib/lf/mesh/hybrid2dp/mesh_factory.h:37: warning: Found recursive @copybrief or @copydoc relation for argument 'MeshFactory::DimWorld()'.
lehrfempp/lib/lf/mesh/hybrid2dp/mesh_factory.h:43: warning: Found recursive @copybrief or @copydoc relation for argument 'MeshFactory::AddPoint()'.
lehrfempp/lib/lf/mesh/hybrid2dp/mesh_factory.h:46: warning: Found recursive @copybrief or @copydoc relation for argument 'MeshFactory::AddPoint()'.
lehrfempp/lib/lf/mesh/hybrid2dp/mesh_factory.h:49: warning: Found recursive @copybrief or @copydoc relation for argument 'MeshFactory::AddEntity()'.
lehrfempp/lib/lf/mesh/hybrid2dp/mesh_factory.h:54: warning: Found recursive @copybrief or @copydoc relation for argument 'MeshFactory::Build()'.

lehrfempp/lib/lf/mesh/hybrid2dp/mesh_factory.h:49: warning: Found recursive @copybrief or @copydoc relation for argument 'MeshFactory::AddEntity()'.
lehrfempp/lib/lf/mesh/hybrid2dp/mesh_factory.h:49: warning: Found recursive @copydetails or @copydoc relation for argument 'MeshFactory::AddEntity()'.
lehrfempp/lib/lf/mesh/hybrid2dp/mesh_factory.h:43: warning: Found recursive @copybrief or @copydoc relation for argument 'MeshFactory::AddPoint()'.
lehrfempp/lib/lf/mesh/hybrid2dp/mesh_factory.h:43: warning: Found recursive @copydetails or @copydoc relation for argument 'MeshFactory::AddPoint()'.
lehrfempp/lib/lf/mesh/hybrid2dp/mesh_factory.h:46: warning: Found recursive @copybrief or @copydoc relation for argument 'MeshFactory::AddPoint()'.
lehrfempp/lib/lf/mesh/hybrid2dp/mesh_factory.h:46: warning: Found recursive @copydetails or @copydoc relation for argument 'MeshFactory::AddPoint()'.
lehrfempp/lib/lf/mesh/hybrid2dp/mesh_factory.h:54: warning: Found recursive @copybrief or @copydoc relation for argument 'MeshFactory::Build()'.
lehrfempp/lib/lf/mesh/hybrid2dp/mesh_factory.h:54: warning: Found recursive @copydetails or @copydoc relation for argument 'MeshFactory::Build()'.
lehrfempp/lib/lf/mesh/hybrid2dp/mesh_factory.h:37: warning: Found recursive @copybrief or @copydoc relation for argument 'MeshFactory::DimWorld()'.
lehrfempp/lib/lf/mesh/hybrid2dp/mesh_factory.h:37: warning: Found recursive @copydetails or @copydoc relation for argument 'MeshFactory::DimWorld()'.

==========

I was unable to fix the following doxygen errors due to various reasons:

warning: @copybrief or @copydoc target 'Mesh::coord_t' not found
There seems to be no entry and documentation Mesh::coord_t

warning: included file lambda_mesh_data_set.cc is not found. Check your EXAMPLE_PATH
Snippets do not seem to work. EXAMPLE_PATH looks fine to me (it is set to "snippets"), but I am not sure where the realtive directory root for doxygen is set

warning: block marked with [usage] for \snippet should appear twice in file lambda_mesh_data_set.cc, found it 0 times
This error message seems to appear always in conjunction with the above error message

/Users/js/Dropbox/NumPDE/lehrfempp/lib/lf/mesh/hybrid2d/mesh_factory.h:33: warning: @copybrief or @copydoc target 'Mesh::AddPoint()' not found
/Users/js/Dropbox/NumPDE/lehrfempp/lib/lf/mesh/hybrid2d/mesh_factory.h:36: warning: @copybrief or @copydoc target 'Mesh::AddPoint()' not found
/Users/js/Dropbox/NumPDE/lehrfempp/lib/lf/mesh/hybrid2d/mesh_factory.h:39: warning: @copybrief or @copydoc target 'Mesh::AddEntity()' not found
/Users/js/Dropbox/NumPDE/lehrfempp/lib/lf/mesh/hybrid2d/mesh_factory.h:44: warning: @copybrief or @copydoc target 'Mesh::Build()' not found
Although methods Mesh::AddPoint, Mesh::AddEntity, and Mesh::Build exist and are documented, Doxygen is not able to copy documentation. I am not sure why, but I suspect it is due to some mismatch in argument type, return type or similar.