### PR TITLE
Fix IntegrationElement for Point

### DIFF
--- a/lib/lf/geometry/point.cc
+++ b/lib/lf/geometry/point.cc
@@ -16,9 +16,8 @@ Eigen::MatrixXd Point::JacobianInverseGramian(
   return Eigen::MatrixXd::Zero(DimGlobal(), 0);
 }
 
-// NOLINTNEXTLINE(misc-unused-parameters)
 Eigen::VectorXd Point::IntegrationElement(const Eigen::MatrixXd& local) const {
-  return Eigen::Matrix<double, 1, 1>::Constant(1.0);
+  return Eigen::MatrixXd::Ones(local.cols(), 1);
 }
 
 std::unique_ptr<Geometry> Point::SubGeometry(dim_t codim, dim_t i) const {

--- a/lib/lf/geometry/test/geometry_tests.cc
+++ b/lib/lf/geometry/test/geometry_tests.cc
@@ -105,8 +105,7 @@ TEST(Geometry, Point) {
   Eigen::MatrixXd points = Eigen::MatrixXd::Random(0, 3);
   checkJacobians(geom, points, 1e-9);
   checkJacobianInverseGramian(geom, points);
-  // TODO: fix inconsistent dimensions for IntegrationElement()
-  // checkIntegrationElement(geom, points);
+  checkIntegrationElement(geom, points);
 }
 
 TEST(Geometry, SegmentO1) {


### PR DESCRIPTION
`geometry::Point::IntegrationElement()` was inconsistent with respect to the [documentation](https://craffael.github.io/lehrfempp/classlf_1_1geometry_1_1_point.html#afd0be38b184b77037ea01e32b4825cac).