### PR TITLE
SegmentO2

### DIFF
--- a/lib/lf/geometry/CMakeLists.txt
+++ b/lib/lf/geometry/CMakeLists.txt
@@ -11,6 +11,8 @@ set(sources
   refinement_pattern.cc
   segment_o1.h
   segment_o1.cc
+  segment_o2.h
+  segment_o2.cc
   tria_o1.h
   tria_o1.cc
   print_info.h

--- a/lib/lf/geometry/geometry.h
+++ b/lib/lf/geometry/geometry.h
@@ -14,6 +14,7 @@
 #include "quad_o1.h"
 #include "refinement_pattern.h"
 #include "segment_o1.h"
+#include "segment_o2.h"
 #include "tria_o1.h"
 
 /**

--- a/lib/lf/geometry/segment_o1.cc
+++ b/lib/lf/geometry/segment_o1.cc
@@ -64,7 +64,7 @@ std::vector<std::unique_ptr<Geometry>> SegmentO1::ChildGeometry(
   // For each child create a geometry object and a unique pointer to it.
   for (int l = 0; l < no_children; l++) {
     // codim == 0:A single child must be described by an interval, that is
-    // two differente lattice coordinates
+    // two different lattice coordinates
     // codim == 1: a point's location is just one number
     LF_VERIFY_MSG(child_polygons[l].rows() == 1,
                   "child_polygons[l].rows() = " << child_polygons[l].rows());

--- a/lib/lf/geometry/segment_o1.h
+++ b/lib/lf/geometry/segment_o1.h
@@ -29,8 +29,9 @@ class SegmentO1 : public Geometry {
    * @see Geometry::ChildGeometry()
    * @see RefinementPattern
    * @param ref_pat three refinement patterns are supported
+   * - rp_nil: empty refinement
    * - rp_copy: just copies the geometry information of the segment
-   * - rp_split, rp_regular: split edge in the middle.
+   * - rp_split: split edge in the middle.
    * @param codim _relative_ codimension of children whose shape is
    *        requested
    */

--- a/lib/lf/geometry/segment_o2.cc
+++ b/lib/lf/geometry/segment_o2.cc
@@ -26,7 +26,7 @@ Eigen::MatrixXd SegmentO2::Global(const Eigen::MatrixXd& local) const {
   for (size_t point = 0; point < local.cols(); ++point) {
     const double x = local(point);
 
-    if (0. <= x and x <= 1.) {
+    if (0. <= x && x <= 1.) {
       global.col(point) = alpha * x * x + beta * x + gamma;
     } else {
       LF_VERIFY_MSG(false,
@@ -51,7 +51,7 @@ Eigen::MatrixXd SegmentO2::Jacobian(const Eigen::MatrixXd& local) const {
   for (size_t point = 0; point < local.cols(); ++point) {
     const double x = local(point);
 
-    if (0. <= x and x <= 1.) {
+    if (0. <= x && x <= 1.) {
       jacobian.col(point) = 2. * alpha * x + beta;
     } else {
       LF_VERIFY_MSG(false,
@@ -108,7 +108,7 @@ std::unique_ptr<Geometry> SegmentO2::SubGeometry(dim_t codim, dim_t i) const {
     return std::make_unique<SegmentO2>(coords_);
   }
   if (codim == 1) {
-    LF_ASSERT_MSG(0 <= i and i <= 2, "i is out of bounds");
+    LF_ASSERT_MSG(0 <= i && i <= 2, "i is out of bounds");
     return std::make_unique<Point>(coords_.col(i));
   }
   LF_VERIFY_MSG(false, "codim is out of bounds");

--- a/lib/lf/geometry/segment_o2.cc
+++ b/lib/lf/geometry/segment_o2.cc
@@ -1,0 +1,9 @@
+/**
+ * @file
+ * @brief Implementation of second-order segments
+ * @author Anian Ruoss
+ * @date   2018-11-18 19:02:17
+ * @copyright MIT License
+ */
+
+#include "segment_o2.h"

--- a/lib/lf/geometry/segment_o2.cc
+++ b/lib/lf/geometry/segment_o2.cc
@@ -21,7 +21,7 @@ Eigen::MatrixXd SegmentO2::Global(const Eigen::MatrixXd& local) const {
   // polynomial of degree 2: alpha * x^2 + beta * x + gamma
   const Eigen::VectorXd alpha = 2. * (vtx1 + vtx0) - 4. * midp;
   const Eigen::VectorXd beta = 4. * midp - 3. * vtx0 - vtx1;
-  const Eigen::VectorXd gamma = vtx0;
+  const Eigen::VectorXd& gamma = vtx0;
 
   for (size_t point = 0; point < local.cols(); ++point) {
     const double x = local(point);
@@ -47,7 +47,6 @@ Eigen::MatrixXd SegmentO2::Jacobian(const Eigen::MatrixXd& local) const {
   // polynomial of degree 2: alpha * x^2 + beta * x + gamma
   const Eigen::VectorXd alpha = 2. * (vtx1 + vtx0) - 4. * midp;
   const Eigen::VectorXd beta = 4. * midp - 3. * vtx0 - vtx1;
-  const Eigen::VectorXd gamma = vtx0;
 
   for (size_t point = 0; point < local.cols(); ++point) {
     const double x = local(point);

--- a/lib/lf/geometry/segment_o2.cc
+++ b/lib/lf/geometry/segment_o2.cc
@@ -18,13 +18,16 @@ Eigen::MatrixXd SegmentO2::Global(const Eigen::MatrixXd& local) const {
   const Eigen::VectorXd vtx1 = coords_.col(1);
   const Eigen::VectorXd midp = coords_.col(2);
 
+  // polynomial of degree 2: alpha * x^2 + beta * x + gamma
+  const Eigen::VectorXd alpha = 2. * (vtx1 + vtx0) - 4. * midp;
+  const Eigen::VectorXd beta = 4. * midp - 3. * vtx0 - vtx1;
+  const Eigen::VectorXd gamma = vtx0;
+
   for (size_t point = 0; point < local.cols(); ++point) {
     const double x = local(point);
 
-    if (0. <= x and x <= 0.5) {
-      global.col(point) = 2. * (midp - vtx0) * x + vtx0;
-    } else if (0.5 < x and x <= 1.) {
-      global.col(point) = 2. * (vtx1 - midp) * x + (2. * midp - vtx1);
+    if (0. <= x and x <= 1.) {
+      global.col(point) = alpha * x * x + beta * x + gamma;
     } else {
       LF_VERIFY_MSG(false,
                     "local coordinate out of bounds for reference element");
@@ -41,15 +44,16 @@ Eigen::MatrixXd SegmentO2::Jacobian(const Eigen::MatrixXd& local) const {
   const Eigen::VectorXd vtx1 = coords_.col(1);
   const Eigen::VectorXd midp = coords_.col(2);
 
+  // polynomial of degree 2: alpha * x^2 + beta * x + gamma
+  const Eigen::VectorXd alpha = 2. * (vtx1 + vtx0) - 4. * midp;
+  const Eigen::VectorXd beta = 4. * midp - 3. * vtx0 - vtx1;
+  const Eigen::VectorXd gamma = vtx0;
+
   for (size_t point = 0; point < local.cols(); ++point) {
     const double x = local(point);
 
-    if (0. <= x and x < 0.5) {
-      jacobian.col(point) = 2. * (midp - vtx0);
-    } else if (x == 0.5) {
-      jacobian.col(point) = (vtx1 - vtx0);
-    } else if (0.5 < x and x <= 1.) {
-      jacobian.col(point) = 2. * (vtx1 - midp);
+    if (0. <= x and x <= 1.) {
+      jacobian.col(point) = 2. * alpha * x + beta;
     } else {
       LF_VERIFY_MSG(false,
                     "local coordinate out of bounds for reference element");

--- a/lib/lf/geometry/segment_o2.cc
+++ b/lib/lf/geometry/segment_o2.cc
@@ -7,3 +7,113 @@
  */
 
 #include "segment_o2.h"
+#include "point.h"
+
+namespace lf::geometry {
+
+Eigen::MatrixXd SegmentO2::Global(const Eigen::MatrixXd& local) const {
+  Eigen::MatrixXd global(DimGlobal(), local.cols());
+
+  const Eigen::VectorXd vtx0 = coords_.col(0);
+  const Eigen::VectorXd vtx1 = coords_.col(1);
+  const Eigen::VectorXd midp = coords_.col(2);
+
+  for (size_t point = 0; point < local.cols(); ++point) {
+    const double x = local(point);
+
+    if (0. <= x and x <= 0.5) {
+      global.col(point) = 2. * (midp - vtx0) * x + vtx0;
+    } else if (0.5 < x and x <= 1.) {
+      global.col(point) = 2. * (vtx1 - midp) * x + (2. * midp - vtx1);
+    } else {
+      LF_VERIFY_MSG(false,
+                    "local coordinate out of bounds for reference element");
+    }
+  }
+
+  return global;
+}
+
+Eigen::MatrixXd SegmentO2::Jacobian(const Eigen::MatrixXd& local) const {
+  Eigen::MatrixXd jacobian(DimGlobal(), DimLocal() * local.cols());
+
+  const Eigen::VectorXd vtx0 = coords_.col(0);
+  const Eigen::VectorXd vtx1 = coords_.col(1);
+  const Eigen::VectorXd midp = coords_.col(2);
+
+  for (size_t point = 0; point < local.cols(); ++point) {
+    const double x = local(point);
+
+    if (0. <= x and x < 0.5) {
+      jacobian.col(point) = 2. * (midp - vtx0);
+    } else if (x == 0.5) {
+      jacobian.col(point) = (vtx1 - vtx0);
+    } else if (0.5 < x and x <= 1.) {
+      jacobian.col(point) = 2. * (vtx1 - midp);
+    } else {
+      LF_VERIFY_MSG(false,
+                    "local coordinate out of bounds for reference element");
+    }
+  }
+
+  return jacobian;
+}
+
+Eigen::MatrixXd SegmentO2::JacobianInverseGramian(
+    const ::Eigen::MatrixXd& local) const {
+  Eigen::MatrixXd jacInvGram(DimGlobal(), DimLocal() * local.cols());
+  Eigen::MatrixXd jacobian = Jacobian(local);
+
+  for (size_t point = 0; point < local.cols(); ++point) {
+    Eigen::MatrixXd jac =
+        jacobian.block(0, point * DimLocal(), DimGlobal(), DimLocal());
+
+    if (DimGlobal() == DimLocal()) {
+      jacInvGram.block(0, point * DimLocal(), DimGlobal(), DimLocal()) =
+          jac.inverse().transpose();
+    } else {
+      jacInvGram.block(0, point * DimLocal(), DimGlobal(), DimLocal()) =
+          jac * (jac.transpose() * jac).inverse();
+    }
+  }
+
+  return jacInvGram;
+}
+
+Eigen::VectorXd SegmentO2::IntegrationElement(
+    const Eigen::MatrixXd& local) const {
+  Eigen::VectorXd intEl(local.cols());
+  Eigen::MatrixXd jacobian = Jacobian(local);
+
+  for (size_t point = 0; point < local.cols(); ++point) {
+    Eigen::MatrixXd jac =
+        jacobian.block(0, point * DimLocal(), DimGlobal(), DimLocal());
+
+    if (DimGlobal() == DimLocal()) {
+      intEl(point) = std::abs(jac.determinant());
+    } else {
+      intEl(point) = std::sqrt((jac.transpose() * jac).determinant());
+    }
+  }
+
+  return intEl;
+}
+
+std::unique_ptr<Geometry> SegmentO2::SubGeometry(dim_t codim, dim_t i) const {
+  if (codim == 0) {
+    LF_ASSERT_MSG(i == 0, "i is out of bounds");
+    return std::make_unique<SegmentO2>(coords_);
+  } else if (codim == 1) {
+    LF_ASSERT_MSG(0 <= i and i <= 2, "i is out of bounds");
+    return std::make_unique<Point>(coords_.col(i));
+  } else {
+    LF_VERIFY_MSG(false, "codim is out of bounds");
+  }
+}
+
+std::vector<std::unique_ptr<Geometry>> SegmentO2::ChildGeometry(
+    const RefinementPattern& ref_pat, base::dim_t codim) const {
+  LF_VERIFY_MSG(false, "refinement for SegmentO2 not implemented yet");
+}
+
+}  // namespace lf::geometry

--- a/lib/lf/geometry/segment_o2.cc
+++ b/lib/lf/geometry/segment_o2.cc
@@ -103,16 +103,17 @@ std::unique_ptr<Geometry> SegmentO2::SubGeometry(dim_t codim, dim_t i) const {
   if (codim == 0) {
     LF_ASSERT_MSG(i == 0, "i is out of bounds");
     return std::make_unique<SegmentO2>(coords_);
-  } else if (codim == 1) {
+  }
+  if (codim == 1) {
     LF_ASSERT_MSG(0 <= i and i <= 2, "i is out of bounds");
     return std::make_unique<Point>(coords_.col(i));
-  } else {
-    LF_VERIFY_MSG(false, "codim is out of bounds");
   }
+  LF_VERIFY_MSG(false, "codim is out of bounds");
 }
 
 std::vector<std::unique_ptr<Geometry>> SegmentO2::ChildGeometry(
-    const RefinementPattern& ref_pat, base::dim_t codim) const {
+    const RefinementPattern& ref_pat,  // NOLINT(misc-unused-parameters)
+    base::dim_t codim) const {         // NOLINT(misc-unused-parameters)
   LF_VERIFY_MSG(false, "refinement for SegmentO2 not implemented yet");
 }
 

--- a/lib/lf/geometry/segment_o2.h
+++ b/lib/lf/geometry/segment_o2.h
@@ -14,8 +14,8 @@
 namespace lf::geometry {
 
 /**
- * @brief A piecewise straight edge defined by the location of its two
- * endpoints and its midpoint
+ * @brief A curved edge parametrized by means of polynomial of degree 2 defined
+ * by the location of its two endpoints and its midpoint
  */
 class SegmentO2 : public Geometry {
  public:

--- a/lib/lf/geometry/segment_o2.h
+++ b/lib/lf/geometry/segment_o2.h
@@ -1,0 +1,12 @@
+/**
+ * @file
+ * @brief Declaration of second-order segments
+ * @author Anian Ruoss
+ * @date   2018-11-18 19:02:17
+ * @copyright MIT License
+ */
+
+#ifndef SEGMENT_O2_H
+#define SEGMENT_O2_H
+
+#endif /* SEGMENT_O2_H */

--- a/lib/lf/geometry/segment_o2.h
+++ b/lib/lf/geometry/segment_o2.h
@@ -9,4 +9,47 @@
 #ifndef SEGMENT_O2_H
 #define SEGMENT_O2_H
 
+#include "geometry_interface.h"
+
+namespace lf::geometry {
+
+/**
+ * @brief A piecewise straight edge defined by the location of its two
+ * endpoints and its midpoint
+ */
+class SegmentO2 : public Geometry {
+ public:
+  explicit SegmentO2(Eigen::Matrix<double, Eigen::Dynamic, 3> coords)
+      : coords_(std::move(coords)) {}
+
+  dim_t DimLocal() const override { return 1; }
+  dim_t DimGlobal() const override { return coords_.rows(); }
+  base::RefEl RefEl() const override { return base::RefEl::kSegment(); }
+  Eigen::MatrixXd Global(const Eigen::MatrixXd& local) const override;
+  Eigen::MatrixXd Jacobian(const Eigen::MatrixXd& local) const override;
+  Eigen::MatrixXd JacobianInverseGramian(
+      const ::Eigen::MatrixXd& local) const override;
+  Eigen::VectorXd IntegrationElement(
+      const Eigen::MatrixXd& local) const override;
+  std::unique_ptr<Geometry> SubGeometry(dim_t codim, dim_t i) const override;
+
+  /** @brief creation of child geometry for the sake of mesh refinement
+   *
+   * @see Geometry::ChildGeometry()
+   * @see RefinementPattern
+   * @param ref_pat three refinement patterns are supported
+   * - rp_nil: empty refinement
+   * - rp_copy: just copies the geometry information of the segment
+   * - rp_split: split edge in the middle.
+   * @param codim _relative_ codimension of children whose shape is requested
+   */
+  std::vector<std::unique_ptr<Geometry>> ChildGeometry(
+      const RefinementPattern& ref_pat, base::dim_t codim) const override;
+
+ private:
+  Eigen::Matrix<double, Eigen::Dynamic, 3> coords_;
+};
+
+}  // namespace lf::geometry
+
 #endif /* SEGMENT_O2_H */

--- a/lib/lf/geometry/test/geometry_tests.cc
+++ b/lib/lf/geometry/test/geometry_tests.cc
@@ -15,9 +15,8 @@
  * Checks if Jacobian() is implemented correctly by comparing it with the
  * symmetric difference quotient approximation
  */
-void checkJacobians(const lf::geometry::Geometry &geom,
-                    const Eigen::MatrixXd &eval_points,
-                    const double tolerance) {
+void checkJacobian(const lf::geometry::Geometry &geom,
+                   const Eigen::MatrixXd &eval_points, const double tolerance) {
   const double h = 1e-6;
 
   const size_t num_points = eval_points.cols();
@@ -200,7 +199,7 @@ void checkSubGeometry(
 void runGeometryChecks(const lf::geometry::Geometry &geom,
                        const Eigen::MatrixXd &eval_points,
                        const double tolerance) {
-  checkJacobians(geom, eval_points, tolerance);
+  checkJacobian(geom, eval_points, tolerance);
   // JacobianInverseGramian is not defined for points
   if (geom.RefEl() != lf::base::RefEl::kPoint()) {
     checkJacobianInverseGramian(geom, eval_points);
@@ -266,6 +265,13 @@ TEST(Geometry, SegmentO1) {
   for (const auto &refPat : segSymmetricRefPats) {
     checkChildGeometryVolume(geom, refPat);
   }
+}
+
+TEST(Geometry, SegmentO2) {
+  lf::geometry::SegmentO2 geom(
+      (Eigen::MatrixXd(2, 3) << 1, 2, 3, 1, 4, 2).finished());
+  auto qr = lf::quad::make_QuadRule(lf::base::RefEl::kSegment(), 5);
+  runGeometryChecks(geom, qr.Points(), 1e-9);
 }
 
 TEST(Geometry, TriaO1) {

--- a/lib/lf/refinement/hybrid2d_refinement_pattern.h
+++ b/lib/lf/refinement/hybrid2d_refinement_pattern.h
@@ -85,7 +85,7 @@ class Hybrid2DRefinementPattern : public geometry::RefinementPattern {
       : geometry::RefinementPattern(ref_el),
         anchor_(anchor),
         ref_pat_(ref_pat),
-        anchor_set_(anchor == idx_nil ? false : true) {
+        anchor_set_(anchor != idx_nil) {
     if (anchor_set_) {
       LF_VERIFY_MSG(
           anchor < ref_el_.NumSubEntities(1),
@@ -204,7 +204,7 @@ class Hybrid2DRefinementPattern : public geometry::RefinementPattern {
   /** @brief set local number of anchor edge */
   Hybrid2DRefinementPattern& setAnchor(lf::base::sub_idx_t anchor) {
     anchor_ = anchor;
-    anchor_set_ = (anchor == idx_nil) ? false : true;
+    anchor_set_ = anchor != idx_nil;
     if (anchor_set_) {
       LF_VERIFY_MSG(
           anchor < ref_el_.NumSubEntities(1),


### PR DESCRIPTION
I implemented the class `SegmentO2`, assuming that the third coordinate is mapped to the midpoint of `RefEl::kSegment()` to keep the numbering consistent with `SegmentO1`.