### PR TITLE
lf_add_library instead of add_library

### DIFF
--- a/lib/lf/refinement/CMakeLists.txt
+++ b/lib/lf/refinement/CMakeLists.txt
@@ -5,7 +5,7 @@ set(sources
   refutils.h refutils.cc
   )
 
-add_library(lf.refinement ${sources})
+lf_add_library(lf.refinement ${sources})
 target_link_libraries(lf.refinement PUBLIC Eigen3::Eigen lf.base lf.geometry lf.io)
 target_compile_features(lf.refinement PUBLIC cxx_std_17)
 


### PR DESCRIPTION
The title pretty much says it all - o/w we can't use the refinement utilities for the exercise problems. 

I didn't spot this the last time I requested a Hunter update unfortunately; Sorry! 

Thanks a lot.