### PR TITLE
Bugfix uscalfe

### DIFF
--- a/examples/ellbvp_linfe/ellbvp_linfe_demo.cc
+++ b/examples/ellbvp_linfe/ellbvp_linfe_demo.cc
@@ -267,7 +267,7 @@ int main(int /*argc*/, const char** /*argv*/) {
     // Update with potential contributions from edges (impedance boundary
     // conditions!). To that end initialize object taking care of local
     // computations on segments. A predicate ensure that computations are
-    // confined to edges on the impredance boundary
+    // confined to edges on the impedance boundary
     lf::uscalfe::MassEdgeMatrixProvider<double, decltype(mf_eta),
                                         decltype(edge_sel_imp)>
         edgemat_builder(fe_space, mf_eta, edge_sel_imp);

--- a/lib/lf/base/ref_el.h
+++ b/lib/lf/base/ref_el.h
@@ -474,6 +474,10 @@ class RefEl {
   /**
    * @brief Return a unique id for this reference element.
    *
+   * The id numbers are contiguous over the known entity types starting from 0.
+   * Thus, this identification number can be used as an array index, if one
+   * wants to store information for (all) type of entities.
+   *
    * #### Usage example
    * @snippet ref_el.cc id
    */

--- a/lib/lf/uscalfe/loc_comp_ellbvp.h
+++ b/lib/lf/uscalfe/loc_comp_ellbvp.h
@@ -373,7 +373,6 @@ class MassEdgeMatrixProvider {
     // quadrature rule
     fe_precomp_ = PrecomputedScalarReferenceFiniteElement(
         fe, quad::make_QuadRule(base::RefEl::kSegment(), 2 * fe->Degree()));
-    LF_ASSERT_MSG(fe_precomp_.isInitialized(), "PFE object not initialized!");
   }
   /**
    * @brief Constructor performing cell-independent initializations
@@ -398,7 +397,6 @@ class MassEdgeMatrixProvider {
                   "Quadrature rule not meant for EDGE entities!");
     // Precompute entity-independent quantities
     fe_precomp_ = PrecomputedScalarReferenceFiniteElement(fe, quadrule);
-    LF_ASSERT_MSG(fe_precomp_.isInitialized(), "PFE object not initialized!");
   }
 
   /**
@@ -768,7 +766,6 @@ class ScalarLoadEdgeVectorProvider {
     // quadrature rule
     pfe_ = PrecomputedScalarReferenceFiniteElement(
         fe, quad::make_QuadRule(base::RefEl::kSegment(), 2 * fe->Degree()));
-    LF_ASSERT_MSG(pfe_.isInitialized(), "PFE object not initialized!");
   }
 
   /** @brief Constructor, performs precomputations
@@ -789,7 +786,6 @@ class ScalarLoadEdgeVectorProvider {
                   "Quadrature rule not meant for EDGE entities!");
     // Precompute entity-independent quantities
     pfe_ = PrecomputedScalarReferenceFiniteElement(fe, quadrule);
-    LF_ASSERT_MSG(pfe_.isInitialized(), "PFE object not initialized!");
   }
 
   /** @brief Default implement: all edges are active */

--- a/lib/lf/uscalfe/loc_comp_ellbvp.h
+++ b/lib/lf/uscalfe/loc_comp_ellbvp.h
@@ -373,7 +373,7 @@ class MassEdgeMatrixProvider {
     // quadrature rule
     fe_precomp_ = PrecomputedScalarReferenceFiniteElement(
         fe, quad::make_QuadRule(base::RefEl::kSegment(), 2 * fe->Degree()));
-    LF_ASSERT_MSG(fe_precomp_.isInitialized(),"PFE object not initialized!");
+    LF_ASSERT_MSG(fe_precomp_.isInitialized(), "PFE object not initialized!");
   }
   /**
    * @brief Constructor performing cell-independent initializations
@@ -398,7 +398,7 @@ class MassEdgeMatrixProvider {
                   "Quadrature rule not meant for EDGE entities!");
     // Precompute entity-independent quantities
     fe_precomp_ = PrecomputedScalarReferenceFiniteElement(fe, quadrule);
-    LF_ASSERT_MSG(fe_precomp_.isInitialized(),"PFE object not initialized!");
+    LF_ASSERT_MSG(fe_precomp_.isInitialized(), "PFE object not initialized!");
   }
 
   /**
@@ -768,7 +768,7 @@ class ScalarLoadEdgeVectorProvider {
     // quadrature rule
     pfe_ = PrecomputedScalarReferenceFiniteElement(
         fe, quad::make_QuadRule(base::RefEl::kSegment(), 2 * fe->Degree()));
-    LF_ASSERT_MSG(pfe_.isInitialized(),"PFE object not initialized!");
+    LF_ASSERT_MSG(pfe_.isInitialized(), "PFE object not initialized!");
   }
 
   /** @brief Constructor, performs precomputations
@@ -789,7 +789,7 @@ class ScalarLoadEdgeVectorProvider {
                   "Quadrature rule not meant for EDGE entities!");
     // Precompute entity-independent quantities
     pfe_ = PrecomputedScalarReferenceFiniteElement(fe, quadrule);
-    LF_ASSERT_MSG(pfe_.isInitialized(),"PFE object not initialized!");
+    LF_ASSERT_MSG(pfe_.isInitialized(), "PFE object not initialized!");
   }
 
   /** @brief Default implement: all edges are active */

--- a/lib/lf/uscalfe/precomputed_scalar_reference_finite_element.h
+++ b/lib/lf/uscalfe/precomputed_scalar_reference_finite_element.h
@@ -20,7 +20,7 @@ namespace lf::uscalfe {
 /**
  * @brief Helper class which stores a ScalarReferenceFiniteElement with
  * precomputed values at the nodes of a quadrature rule.
- * @tparam SCALAR The scalar type of the shape functions.
+ * @tparam SCALAR The scalar type of the shape functions, e.g. `double`
  *
  * This class does essentially three things:
  * -# It wraps any ScalarReferenceFiniteElement and forwards all calls to the
@@ -28,6 +28,11 @@ namespace lf::uscalfe {
  * -# It provides access to a quad::QuadratureRule (passed in constructor)
  * -# It provides additional member functions to access the precomputed values
  * -# the shape functions/gradients at the nodes of the quadrature rule.
+ *
+ * Precomputing entity-independent quantities boost efficiency in the context of
+ * parametric finite element methods provided that a uniform quadrature rule is
+ * used for local computations on all mesh entities of the same topological
+ * type.
  */
 template <class SCALAR>
 class PrecomputedScalarReferenceFiniteElement
@@ -59,6 +64,13 @@ class PrecomputedScalarReferenceFiniteElement
         qr_(std::move(qr)),
         shap_fun_(fe_->EvalReferenceShapeFunctions(qr_.Points())),
         grad_shape_fun_(fe_->GradientsReferenceShapeFunctions(qr_.Points())) {}
+
+  /**
+   * @brief Tells initialization status of object
+   *
+   * An object is in an undefined state when built by the default constructor
+   */
+  inline bool isInitialized() const { return (fe_ != nullptr); }
 
   base::RefEl RefEl() const override {
     LF_ASSERT_MSG(fe_ != nullptr, "Not initialized.");


### PR DESCRIPTION
Added checks and assertions in order to catch situations where specifications of local shape functions are missing. 

Also added new constructors taking quadrature rule arguments for classes definiting ENTITY_MATRIX_PROVIDERS and ENTITY_VECTOR_PROVIDERS.

Should be merged quickly, because a homework problem depends on it. 