### PR TITLE
Custom quadrature rule for ScalarLoadElementVectorProvider

### DIFF
--- a/lib/lf/uscalfe/loc_comp_ellbvp.h
+++ b/lib/lf/uscalfe/loc_comp_ellbvp.h
@@ -630,7 +630,7 @@ ScalarLoadElementVectorProvider<SCALAR, FUNCTOR>::
         // quadrature rules
         fe_precomp_[ref_el.Id()] =
             PrecomputedScalarReferenceFiniteElement<SCALAR>(
-                fe, quad::make_QuadRule(ref_el, 2 * fe->Degree()));
+                fe, qr);
       } else {
         // Quadrature rule is missing for an entity type for which
         // local shape functions are available

--- a/lib/lf/uscalfe/loc_comp_ellbvp.h
+++ b/lib/lf/uscalfe/loc_comp_ellbvp.h
@@ -629,8 +629,7 @@ ScalarLoadElementVectorProvider<SCALAR, FUNCTOR>::
         // Precompute cell-independent quantities using the user-supplied
         // quadrature rules
         fe_precomp_[ref_el.Id()] =
-            PrecomputedScalarReferenceFiniteElement<SCALAR>(
-                fe, qr);
+            PrecomputedScalarReferenceFiniteElement<SCALAR>(fe, qr);
       } else {
         // Quadrature rule is missing for an entity type for which
         // local shape functions are available


### PR DESCRIPTION
There was a bug in ScalarLoadElementVectorProvider which made it such that it used only the default quadrature rule. I fixed it. 

I would be grateful if a new version could be released via hunter soon because I need to use this feature.