### PR TITLE
fix issue #129

### DIFF
--- a/lib/lf/mesh/hybrid2d/mesh.cc
+++ b/lib/lf/mesh/hybrid2d/mesh.cc
@@ -563,7 +563,7 @@ Mesh::Mesh(dim_t dim_world, NodeCoordList nodes, EdgeList edges, CellList cells,
       nodeHasSuperEntity[p1] = true;
 
       // make sure that the edge belongs to at least one cell:
-      LF_ASSERT_MSG(!edge.second.adj_cells_list.empty(),
+      LF_VERIFY_MSG(!edge.second.adj_cells_list.empty(),
                     "Mesh is incomplete: Edge with global index "
                         << edge.second.edge_global_index
                         << " does not belong to a cell.");
@@ -583,7 +583,7 @@ Mesh::Mesh(dim_t dim_world, NodeCoordList nodes, EdgeList edges, CellList cells,
   if (check_completeness) {
     // Check that all nodes have a super entity:
     for (int i = 0; i < nodes.size(); ++i) {
-      LF_ASSERT_MSG(nodeHasSuperEntity[i],
+      LF_VERIFY_MSG(nodeHasSuperEntity[i],
                     "Mesh is incomplete: Node with global index "
                         << i << " is not part of any edge.");
     }

--- a/lib/lf/mesh/hybrid2d/mesh.cc
+++ b/lib/lf/mesh/hybrid2d/mesh.cc
@@ -167,7 +167,8 @@ class EndpointIndexPair {
 // EdgeList = std::vector<std::pair<std::array<size_type, 2>, GeometryPtr>>;
 // CellList = std::vector<std::pair<std::array<size_type, 4>, GeometryPtr>>;
 // **********************************************************************
-Mesh::Mesh(dim_t dim_world, NodeCoordList nodes, EdgeList edges, CellList cells)
+Mesh::Mesh(dim_t dim_world, NodeCoordList nodes, EdgeList edges, CellList cells,
+           bool check_completeness)
     : dim_world_(dim_world) {
   // Auxiliary data type for gathering information about cells adjacent to an
   // edge
@@ -230,6 +231,7 @@ Mesh::Mesh(dim_t dim_world, NodeCoordList nodes, EdgeList edges, CellList cells)
   }
   EdgeMap edge_map;
   glb_idx_t edge_index = 0;  // position in the array gives index of edge
+
   for (auto &e : edges) {
     // Node indices of endpoints: the KEY
     std::array<size_type, 2> end_nodes(e.first);
@@ -260,7 +262,7 @@ Mesh::Mesh(dim_t dim_world, NodeCoordList nodes, EdgeList edges, CellList cells)
       if (nodes[end_nodes[j]] == nullptr) {
         // if no geometry for node exists request geomtry for an endpoint of the
         // edge Note: endpoints are entities of relative co-dimension 1
-        nodes[end_nodes[j]] = std::move(e.second->SubGeometry(1, j));
+        nodes[end_nodes[j]] = e.second->SubGeometry(1, j);
       }
     }
 
@@ -303,6 +305,7 @@ Mesh::Mesh(dim_t dim_world, NodeCoordList nodes, EdgeList edges, CellList cells)
   if (output_ctrl_ > 0) {
     std::cout << "Scanning list of cells" << std::endl;
   }
+
   for (const auto &c : cells) {
     // node indices of corners of cell c
     const std::array<size_type, 4> &cell_node_list(c.first);
@@ -349,8 +352,7 @@ Mesh::Mesh(dim_t dim_world, NodeCoordList nodes, EdgeList edges, CellList cells)
         if (nodes[cell_node_list[j]] == nullptr) {
           // if no geometry for node exists request geomtry for an vertex from
           // the cell Note: vertices are entities of relative co-dimension 2
-          nodes[cell_node_list[j]] =
-              std::move(cell_geometry->SubGeometry(2, j));
+          nodes[cell_node_list[j]] = cell_geometry->SubGeometry(2, j);
         }
       }
     }
@@ -387,7 +389,7 @@ Mesh::Mesh(dim_t dim_world, NodeCoordList nodes, EdgeList edges, CellList cells)
         // Inherit geometry of edge from adjacent cell
         GeometryPtr edge_geo_ptr;
         if (cell_geometry) {
-          edge_geo_ptr = std::move(cell_geometry->SubGeometry(1, j));
+          edge_geo_ptr = cell_geometry->SubGeometry(1, j);
         }
         // Beginning of list of adjacent elements
         AdjCellsList single_cell_list{edge_cell_info};
@@ -500,6 +502,13 @@ Mesh::Mesh(dim_t dim_world, NodeCoordList nodes, EdgeList edges, CellList cells)
   // Initialized vector of Edge entities here
   segments_.reserve(no_of_edges);
 
+  // if we check for mesh completeness, initialize a vector that stores for
+  // every node if he has a super entity.
+  std::vector<bool> nodeHasSuperEntity;
+  if (check_completeness) {
+    nodeHasSuperEntity.resize(nodes.size(), false);
+  }
+
   // Note: the variable edge_index contains the number externally supplied
   // edges, whose index must agree with their position in the
   // 'edges' array.
@@ -548,6 +557,18 @@ Mesh::Mesh(dim_t dim_world, NodeCoordList nodes, EdgeList edges, CellList cells)
       edge_index++;
     }
 
+    if (check_completeness) {
+      // record that the nodes of this edge have a super-entity (this edge):
+      nodeHasSuperEntity[p0] = true;
+      nodeHasSuperEntity[p1] = true;
+
+      // make sure that the edge belongs to at least one cell:
+      LF_ASSERT_MSG(!edge.second.adj_cells_list.empty(),
+                    "Mesh is incomplete: Edge with global index "
+                        << edge.second.edge_global_index
+                        << " does not belong to a cell.");
+    }
+
     // Diagnostics
     if (output_ctrl_ > 10) {
       std::cout << "Registering edge " << edge.second.edge_global_index << ": "
@@ -559,6 +580,14 @@ Mesh::Mesh(dim_t dim_world, NodeCoordList nodes, EdgeList edges, CellList cells)
   }  // end loop over all edges
   LF_ASSERT_MSG(edge_index == no_of_edges, "Edge index mismatch");
 
+  if (check_completeness) {
+    // Check that all nodes have a super entity:
+    for (int i = 0; i < nodes.size(); ++i) {
+      LF_ASSERT_MSG(nodeHasSuperEntity[i],
+                    "Mesh is incomplete: Node with global index "
+                        << i << " is not part of any edge.");
+    }
+  }
   // ======================================================================
   // NEXT STEP: Create cells
 

--- a/lib/lf/mesh/hybrid2d/mesh.h
+++ b/lib/lf/mesh/hybrid2d/mesh.h
@@ -54,6 +54,7 @@ class Mesh : public mesh::Mesh {
   std::vector<hybrid2d::Triangle> trias_;
   /** @brief array of quadrilateral cell objects, oo-dimension 0 */
   std::vector<hybrid2d::Quadrilateral> quads_;
+
   /** @brief Auxliary array of cell (co-dim ==0 entities) pointers
    *
    * This array serves two purposes. It facilitates the construction
@@ -75,43 +76,40 @@ class Mesh : public mesh::Mesh {
    * @param dim_world Dimension of the ambient space.
    * @param nodes sequential container of node coordinates
    * @param edges sequential container of pairs of
-                  (i) vectors of indices of the nodes of an edge
-                  (ii) pointers to the geometry object describing an edge
+   *               (i) vectors of indices of the nodes of an edge
+   *               (ii) pointers to the geometry object describing an edge
    * @param cells sequential container of pairs of
-                  (i) vectors of indices of the nodes of a cell
-                  (ii) pointers to the geometry object for the cell
+   *               (i) vectors of indices of the nodes of a cell
+   *               (ii) pointers to the geometry object for the cell
+   * @param check_completeness If set to true, the constructor will check that
+   * the mesh is topologically complete. That means that every entity with
+   * codimension `codim>0` is a subentity of at least one entity with
+   * codimension `codim-1`. If `check_completeness = true` and the mesh is not
+   * complete, an assert will fail.
    *
    * ### Shape guessing
    *
    * Shape information usually supplied by a unique pointer to a
-   lf::geometry::Geometry
-   * object attached to an entity may be missing for some of the entities. In
-   this
-   * case the constructor tries to reconstruct the shape from that of other
-   entities.
+   * lf::geometry::Geometry object attached to an entity may be missing for some
+   * of the entities. In this case the constructor tries to reconstruct the
+   * shape from that of other entities.
    *
    * The main example is missing geometry information for nodes or edges. In
-   this case
-   * a call to the lf::geometry::SubGeometry() method of cell entities is used
-   to
-   * generate shape information for its lower-dimensional sub-entities. Note
-   that
-   * any adjacent cell can be used and no selection rule is given.
+   * this case a call to the lf::geometry::SubGeometry() method of cell entities
+   * is used to generate shape information for its lower-dimensional
+   * sub-entities. Note that any adjacent cell can be used and no selection rule
+   * is given.
    *
    * Even cells without shape information may be passed. In this case the
-   current implementation
-   * builds a cell with straight edges of type lf::geometry::TriaO1 (in the case
-   of a topological
-   * triangle) or lf::geometry::QuadO1 (in the case of a quadrilateral) from the
-   node positions.
-   * The shape of edges is not taken into account.
+   * current implementation builds a cell with straight edges of type
+   * lf::geometry::TriaO1 (in the case of a topological triangle) or
+   * lf::geometry::QuadO1 (in the case of a quadrilateral) from the node
+   * positions. The shape of edges is not taken into account.
    *
    * An extreme situation is marked by passing node positions as the only
-   geometric information
-   * together with topological node-cell incidence relationships. In this case
-   the constructor
-   * will build a mesh with straight edges throughout, type
-   lf::geometry::SegmentO1.
+   * geometric information together with topological node-cell incidence
+   * relationships. In this case the constructor will build a mesh with straight
+   * edges throughout, type lf::geometry::SegmentO1.
    *
    * ### Missing entities
    *
@@ -124,7 +122,8 @@ class Mesh : public mesh::Mesh {
    *        that is the n-th node in the container has index n-1.
    *
    */
-  Mesh(dim_t dim_world, NodeCoordList nodes, EdgeList edges, CellList cells);
+  Mesh(dim_t dim_world, NodeCoordList nodes, EdgeList edges, CellList cells,
+       bool check_completeness);
 
   friend class MeshFactory;
 

--- a/lib/lf/mesh/hybrid2d/mesh_factory.cc
+++ b/lib/lf/mesh/hybrid2d/mesh_factory.cc
@@ -103,8 +103,9 @@ std::shared_ptr<mesh::Mesh> MeshFactory::Build() {
 
   // Obtain points to new mesh object; the actual construction of the
   // mesh is done by the constructor of that object
-  mesh::Mesh* mesh_ptr = new hybrid2d::Mesh(
-      dim_world_, std::move(nodes_), std::move(edges_), std::move(elements_));
+  mesh::Mesh* mesh_ptr =
+      new hybrid2d::Mesh(dim_world_, std::move(nodes_), std::move(edges_),
+                         std::move(elements_), check_completeness_);
 
   // Clear all information supplied to the MeshFactory object
   nodes_ = hybrid2d::Mesh::NodeCoordList{};  // .clear();

--- a/lib/lf/mesh/hybrid2d/mesh_factory.h
+++ b/lib/lf/mesh/hybrid2d/mesh_factory.h
@@ -31,8 +31,14 @@ class MeshFactory : public mesh::MeshFactory {
    *        mesh.
    * @param dim_world The dimension of the euclidean space in which the
    *                  mesh is embedded.
+   * @param check_completeness If set to true, calling Build() will check that
+   * the mesh is topologically complete. That means that every entity with
+   * codimension `codim>0` is a subentity of at least one entity with
+   * codimension `codim-1`. If `check_completeness = true` and the mesh is not
+   * complete, an assert will fail.
    */
-  explicit MeshFactory(dim_t dim_world) : dim_world_(dim_world) {}
+  explicit MeshFactory(dim_t dim_world, bool check_completeness = true)
+      : dim_world_(dim_world), check_completeness_(check_completeness) {}
 
   dim_t DimWorld() const override { return dim_world_; }
 
@@ -58,6 +64,10 @@ class MeshFactory : public mesh::MeshFactory {
   hybrid2d::Mesh::NodeCoordList nodes_;
   hybrid2d::Mesh::EdgeList edges_;
   hybrid2d::Mesh::CellList elements_;
+
+  // If set to true, the Build() method will check whether all sub-entities
+  // belong to at least one entity */
+  bool check_completeness_;
 
  public:
   // Switch for verbosity level of output


### PR DESCRIPTION
Adds a flag to hybrid2d::MeshFactory with which the user can control whether it should be checked if the mesh is complete. By default the flag is set and everytime a hybrid2d mesh is built, the programm will make sure that the mesh is complete.