### PR TITLE
Add support for second order elements in Matplotlib

### DIFF
--- a/examples/refinement/second_order_demo.cc
+++ b/examples/refinement/second_order_demo.cc
@@ -44,6 +44,11 @@ int main() {
           TikzOutputCtrl::RenderCells | TikzOutputCtrl::CellNumbering |
               TikzOutputCtrl::VerticeNumbering | TikzOutputCtrl::NodeNumbering |
               TikzOutputCtrl::EdgeNumbering | TikzOutputCtrl::SecondOrder);
+
+      lf::io::writeMatplotlib(*mesh,
+                              mesh_name.substr(0, mesh_name.find_last_of('.')) +
+                                  "_" + std::to_string(step) + ".txt",
+                              true);
     }
   }
 

--- a/lib/lf/io/write_matplotlib.h
+++ b/lib/lf/io/write_matplotlib.h
@@ -1,6 +1,6 @@
 /**
  * @file
- * @brief Declares the writeMatplotlib function which writes a mesh to a .csv
+ * @brief Declares the writeMatplotlib function which writes a mesh to a .txt
  *        file which can be visualized with matplotlib
  * @author Anian Ruoss
  * @date   2018-10-08 18:27:17
@@ -18,9 +18,9 @@ namespace lf::io {
 /**
  * @brief Write affine triangulation data to file in matplotlib format
  * @param mesh the mesh to be stored to file
- * @param filename name of output file: .csv appended unless present
+ * @param filename name of output file: .txt appended unless present
  *
- * This function creates a .csv file containing all relevant information
+ * This function creates a .txt file containing all relevant information
  * about the given mesh in the following format:
  *
  * Points:
@@ -32,9 +32,10 @@ namespace lf::io {
  * Triangles/Quadrilaterals:
  * codim, index, segment1_idx, segment2_idx, ...
  *
- * The .csv file can be read by plot_mesh.py to visualize the mesh
+ * The .txt file can be read by plot_mesh.py to visualize the mesh
  */
-void writeMatplotlib(const lf::mesh::Mesh &mesh, std::string filename);
+void writeMatplotlib(const lf::mesh::Mesh &mesh, std::string filename,
+                     bool second_order);
 
 }  // namespace lf::io
 

--- a/lib/lf/mesh/hybrid2d/mesh.cc
+++ b/lib/lf/mesh/hybrid2d/mesh.cc
@@ -31,7 +31,7 @@ base::ForwardRange<const Entity> Mesh::Entities(unsigned codim) const {
     case 2:
       return {points_.begin(), points_.end()};
     default: {
-      LF_VERIFY_MSG(false, "Something is horribyl wrong, codim = " +
+      LF_VERIFY_MSG(false, "Something is horribly wrong, codim = " +
                                std::to_string(codim) + " is out of bounds.");
       return {
           base::ForwardIterator<const Entity>(static_cast<Entity *>(nullptr)),


### PR DESCRIPTION
I implemented the second order plotting functionality in Matplotlib. Interestingly, the same problems arise as with TikZ:

![failure1](https://user-images.githubusercontent.com/18675644/56932666-e5ae3d80-6ae4-11e9-8212-f0e9f8a32109.png)
![failure2](https://user-images.githubusercontent.com/18675644/56932668-e646d400-6ae4-11e9-8d3f-368db8c5a781.png)

@hiptmair do you think that the parametrization just breaks down at these points?

Otherwise, the plots look fine:

- TriaO1
![trias_o1](https://user-images.githubusercontent.com/18675644/56932722-1c845380-6ae5-11e9-8625-c7390ce2d6bf.png)
- TriaO2
![trias_o2](https://user-images.githubusercontent.com/18675644/56932726-21490780-6ae5-11e9-800c-a873a2224f7c.png)
- QuadO1
![quads_o1](https://user-images.githubusercontent.com/18675644/56932698-ff4f8500-6ae4-11e9-8bb2-81ca9d28629c.png)
- QuadO2
![quads_o2](https://user-images.githubusercontent.com/18675644/56932700-ff4f8500-6ae4-11e9-8b0b-15e0fec7a15a.png)