### PR TITLE
Hunter: disable BUILD_GMOCK

### DIFF
--- a/cmake/Hunter/config.cmake
+++ b/cmake/Hunter/config.cmake
@@ -1,4 +1,4 @@
 # This file specifies additional data for the dependencies that are imported via hunter
 hunter_config(Boost VERSION 1.66.0)
 hunter_config(Eigen VERSION 3.3.5)
-hunter_config(GTest VERSION 1.8.0-hunter-p11)
+hunter_config(GTest VERSION 1.8.0-hunter-p11 CMAKE_ARGS BUILD_GTEST=ON BUILD_GMOCK=OFF)


### PR DESCRIPTION
When trying to build the project on my machine, the build already failed at the configure step, when Hunter is compiling the googletest dependency. See hunter-packages/googletest#27 for the exact error messages.

Steps to reproduce:
```bash
mkdir build
cd build
cmake ..
```

My system:
Arch Linux on 5.1.15-arch1-1-ARCH
cmake 3.14.5
g++ 9.1.0
GNU Make 4.2.1

The error only occurs when building with gmock, and since this project doesn't use gmock at all, the error can safely be fixed by disabling the build of gmock entirely, as is done in this PR.
