### PR TITLE
fix g++9 compilation

### DIFF
--- a/cmake/Hunter/config.cmake
+++ b/cmake/Hunter/config.cmake
@@ -1,4 +1,4 @@
 # This file specifies additional data for the dependencies that are imported via hunter
 hunter_config(Boost VERSION 1.66.0)
 hunter_config(Eigen VERSION 3.3.5)
-hunter_config(GTest VERSION 1.8.0-hunter-p11)
+hunter_config(GTest URL "https://github.com/google/googletest/archive/release-1.8.1.tar.gz" SHA1 "152b849610d91a9dfa1401293f43230c2e0c33f8")

--- a/examples/base/CMakeLists.txt
+++ b/examples/base/CMakeLists.txt
@@ -4,7 +4,7 @@ set(reo_sources ref_el_output.cc)
 
 add_executable(examples.base.ref_el_output ${reo_sources})
 
-target_link_libraries(examples.base.ref_el_output PUBLIC Eigen3::Eigen Boost::boost GTest::main lf.mesh.test_utils lf.mesh.utils)
+target_link_libraries(examples.base.ref_el_output PUBLIC Eigen3::Eigen Boost::boost GTest::gtest_main lf.mesh.test_utils lf.mesh.utils)
 
 add_custom_target(examples.base.ref_el_output_run COMMAND examples.base.ref_el_output)
 add_dependencies(examples_run examples.base.ref_el_output_run)

--- a/examples/base/comm/CMakeLists.txt
+++ b/examples/base/comm/CMakeLists.txt
@@ -4,7 +4,7 @@ outside.cc
 outside.h
 )
 add_executable(examples.base.comm.comm_demo ${comm_sources})
-target_link_libraries(examples.base.comm.comm_demo PUBLIC Eigen3::Eigen Boost::boost Boost::program_options GTest::main lf.base)
+target_link_libraries(examples.base.comm.comm_demo PUBLIC Eigen3::Eigen Boost::boost Boost::program_options GTest::gtest_main lf.base)
 add_custom_target(examples.base.comm.comm_demo_run COMMAND examples.base.comm.comm_demo)
 add_dependencies(examples_run examples.base.comm.comm_demo_run)
 

--- a/examples/geometry/geometry_output/CMakeLists.txt
+++ b/examples/geometry/geometry_output/CMakeLists.txt
@@ -5,6 +5,6 @@ set(geometry_output_sources geometry_output.cc)
 add_executable(examples.geometry.geometry_output ${geometry_output_sources})
 
 # Target link libraries? See similar file for base example
-target_link_libraries(examples.geometry.geometry_output PUBLIC Eigen3::Eigen Boost::boost GTest::main lf.mesh.hybrid2d lf.mesh.test_utils lf.mesh.utils)
+target_link_libraries(examples.geometry.geometry_output PUBLIC Eigen3::Eigen Boost::boost GTest::gtest_main lf.mesh.hybrid2d lf.mesh.test_utils lf.mesh.utils)
 add_custom_target(examples.geometry.geometry_output_run COMMAND examples.geometry.geometry_output)
 add_dependencies(examples_run examples.geometry.geometry_output_run)

--- a/examples/io/test_mesh_output/CMakeLists.txt
+++ b/examples/io/test_mesh_output/CMakeLists.txt
@@ -2,6 +2,6 @@
 set(test_mesh_output_sources test_mesh_output_demo.cc)
 add_executable(examples.io.test_mesh_output ${test_mesh_output_sources})
 target_link_libraries(examples.io.test_mesh_output PUBLIC Eigen3::Eigen
-  Boost::boost GTest::main lf.io lf.mesh.hybrid2d lf.mesh.test_utils lf.mesh.utils lf.io)
+  Boost::boost GTest::gtest_main lf.io lf.mesh.hybrid2d lf.mesh.test_utils lf.mesh.utils lf.io)
 add_custom_target(examples.io.test_mesh_output_run COMMAND examples.io.test_mesh_output)
 add_dependencies(examples_run examples.io.test_mesh_output_run)

--- a/examples/mesh/CMakeLists.txt
+++ b/examples/mesh/CMakeLists.txt
@@ -4,7 +4,7 @@ set(mesh_entity_sources mesh_entity_output.cc)
 
 add_executable(examples.mesh.mesh_entity_output ${mesh_entity_sources})
 target_link_libraries(examples.mesh.mesh_entity_output PUBLIC Eigen3::Eigen
-  Boost::boost GTest::main lf.io lf.mesh.hybrid2d lf.mesh.test_utils lf.mesh.utils)
+  Boost::boost GTest::gtest_main lf.io lf.mesh.hybrid2d lf.mesh.test_utils lf.mesh.utils)
 add_custom_target(examples.mesh.mesh_entity_output_run COMMAND examples.mesh.mesh_entity_output)
 add_dependencies(examples_run examples.mesh.mesh_entity_output_run)
 

--- a/lib/lf/assemble/test/CMakeLists.txt
+++ b/lib/lf/assemble/test/CMakeLists.txt
@@ -7,7 +7,7 @@ set(sources
 
 add_executable(lf.assemble.test ${sources})
 target_link_libraries(lf.assemble.test PUBLIC
-  Eigen3::Eigen Boost::boost GTest::main lf.mesh lf.assemble
+  Eigen3::Eigen Boost::boost GTest::gtest_main lf.mesh lf.assemble
   lf.mesh.hybrid2d lf.mesh.utils lf.mesh.test_utils)
 target_compile_features(lf.assemble.test PUBLIC cxx_std_17)
 gtest_discover_tests(lf.assemble.test)

--- a/lib/lf/base/test/CMakeLists.txt
+++ b/lib/lf/base/test/CMakeLists.txt
@@ -7,5 +7,5 @@ set(sources
 )
 
 add_executable(lf.base.test ${sources})
-target_link_libraries(lf.base.test PUBLIC Eigen3::Eigen Boost::boost GTest::main lf.base)
+target_link_libraries(lf.base.test PUBLIC Eigen3::Eigen Boost::boost GTest::gtest_main lf.base)
 gtest_discover_tests(lf.base.test)

--- a/lib/lf/geometry/test/CMakeLists.txt
+++ b/lib/lf/geometry/test/CMakeLists.txt
@@ -9,7 +9,7 @@ set(sources
 
 add_executable(lf.geometry.test ${sources})
 target_link_libraries(lf.geometry.test
-  PUBLIC Eigen3::Eigen Boost::boost GTest::main
+  PUBLIC Eigen3::Eigen Boost::boost GTest::gtest_main
   lf.base
   lf.geometry
   lf.geometry.test_utils

--- a/lib/lf/geometry/test_utils/CMakeLists.txt
+++ b/lib/lf/geometry/test_utils/CMakeLists.txt
@@ -15,7 +15,7 @@ set(sources
 
 lf_add_library(lf.geometry.test_utils ${sources})
 target_link_libraries(lf.geometry.test_utils PUBLIC
-  GTest::main
+  GTest::gtest_main
   lf.base
   lf.geometry
   lf.quad

--- a/lib/lf/io/test/CMakeLists.txt
+++ b/lib/lf/io/test/CMakeLists.txt
@@ -8,5 +8,5 @@ set(sources
 )
 
 add_executable(lf.io.test ${sources})
-target_link_libraries(lf.io.test PUBLIC Eigen3::Eigen Boost::boost GTest::main lf.io lf.io.test_utils lf.mesh.hybrid2d lf.mesh.test_utils lf.refinement)
+target_link_libraries(lf.io.test PUBLIC Eigen3::Eigen Boost::boost GTest::gtest_main lf.io lf.io.test_utils lf.mesh.hybrid2d lf.mesh.test_utils lf.refinement)
 gtest_discover_tests(lf.io.test)

--- a/lib/lf/io/test_utils/CMakeLists.txt
+++ b/lib/lf/io/test_utils/CMakeLists.txt
@@ -5,4 +5,4 @@ set(sources
 )
 
 add_library(lf.io.test_utils ${sources})
-target_link_libraries(lf.io.test_utils PUBLIC Eigen3::Eigen Boost::boost GTest::main lf.io lf.mesh.hybrid2d)
+target_link_libraries(lf.io.test_utils PUBLIC Eigen3::Eigen Boost::boost GTest::gtest_main lf.io lf.mesh.hybrid2d)

--- a/lib/lf/mesh/hybrid2d/test/CMakeLists.txt
+++ b/lib/lf/mesh/hybrid2d/test/CMakeLists.txt
@@ -7,7 +7,7 @@ set(sources
 )
 
 add_executable(lf.mesh.hybrid2d.test ${sources})
-target_link_libraries(lf.mesh.hybrid2d.test PUBLIC Eigen3::Eigen Boost::boost GTest::main
+target_link_libraries(lf.mesh.hybrid2d.test PUBLIC Eigen3::Eigen Boost::boost GTest::gtest_main
   lf.io
   lf.mesh.hybrid2d
   lf.mesh.test_utils
@@ -21,7 +21,7 @@ gtest_discover_tests(lf.mesh.hybrid2d.test)
 # )
 
 # add_executable(lf.mesh.orientation.test ${orisources})
-# target_link_libraries(lf.mesh.orientation.test PUBLIC Eigen3::Eigen Boost::boost GTest::main
+# target_link_libraries(lf.mesh.orientation.test PUBLIC Eigen3::Eigen Boost::boost GTest::gtest_main
 #   lf.mesh.hybrid2d
 #   lf.mesh.test_utils
 #   lf.mesh.utils)

--- a/lib/lf/mesh/test_utils/CMakeLists.txt
+++ b/lib/lf/mesh/test_utils/CMakeLists.txt
@@ -13,4 +13,4 @@ set(sources
 )
 
 lf_add_library(lf.mesh.test_utils ${sources})
-target_link_libraries(lf.mesh.test_utils PUBLIC Eigen3::Eigen Boost::boost GTest::main lf.mesh lf.mesh.hybrid2d)
+target_link_libraries(lf.mesh.test_utils PUBLIC Eigen3::Eigen Boost::boost GTest::gtest_main lf.mesh lf.mesh.hybrid2d)

--- a/lib/lf/mesh/utils/test/CMakeLists.txt
+++ b/lib/lf/mesh/utils/test/CMakeLists.txt
@@ -10,7 +10,7 @@ set(sources
 
 add_executable(lf.mesh.utils.test ${sources})
 target_link_libraries(lf.mesh.utils.test
-  PUBLIC Eigen3::Eigen Boost::boost GTest::main
+  PUBLIC Eigen3::Eigen Boost::boost GTest::gtest_main
   lf.io
   lf.mesh.hybrid2d
   lf.mesh.utils

--- a/lib/lf/quad/test/CMakeLists.txt
+++ b/lib/lf/quad/test/CMakeLists.txt
@@ -8,5 +8,5 @@ set(sources
 )
 
 add_executable(lf.quad.test ${sources})
-target_link_libraries(lf.quad.test PUBLIC Eigen3::Eigen Boost::boost GTest::main lf.base lf.quad)
+target_link_libraries(lf.quad.test PUBLIC Eigen3::Eigen Boost::boost GTest::gtest_main lf.base lf.quad)
 gtest_discover_tests(lf.quad.test)

--- a/lib/lf/refinement/test/CMakeLists.txt
+++ b/lib/lf/refinement/test/CMakeLists.txt
@@ -11,7 +11,7 @@ set(sources
 
 add_executable(lf.refinement.test ${sources})
 target_link_libraries(lf.refinement.test
-  PUBLIC Eigen3::Eigen Boost::boost GTest::main
+  PUBLIC Eigen3::Eigen Boost::boost GTest::gtest_main
   lf.refinement
   lf.mesh.hybrid2d
   lf.mesh.test_utils
@@ -30,7 +30,7 @@ set(rrt_sources
 
 add_executable(lf.refinement.rrt_test ${rrt_sources})
 target_link_libraries(lf.refinement.rrt_test
-  PUBLIC Eigen3::Eigen Boost::boost GTest::main
+  PUBLIC Eigen3::Eigen Boost::boost GTest::gtest_main
   lf.refinement
   lf.mesh.hybrid2d
   lf.mesh.test_utils

--- a/lib/lf/uscalfe/test/CMakeLists.txt
+++ b/lib/lf/uscalfe/test/CMakeLists.txt
@@ -22,7 +22,7 @@ set(src
 add_executable(lf.uscalfe.test ${src})
 
 target_link_libraries(lf.uscalfe.test PUBLIC
-  Eigen3::Eigen Boost::boost GTest::main lf.mesh lf.refinement lf.assemble lf.quad
+  Eigen3::Eigen Boost::boost GTest::gtest_main lf.mesh lf.refinement lf.assemble lf.quad
   lf.mesh.hybrid2d lf.io lf.io.test_utils lf.mesh.utils lf.mesh.test_utils lf.uscalfe)
 target_compile_features(lf.uscalfe.test PUBLIC cxx_std_17)
 gtest_discover_tests(lf.uscalfe.test)


### PR DESCRIPTION
This PR modifies the build system so that GTest 1.8.1 instead of 1.8.0 is used. This fixes the problem with G++9 compilation of LehrFEM++.