### PR TITLE
operator* + transpose for MeshFunctions 

### DIFF
--- a/doc/doxygen/snippets/mesh_function_binary.cc
+++ b/doc/doxygen/snippets/mesh_function_binary.cc
@@ -47,4 +47,36 @@ void subtraction() {
   //! [subtract]
 }
 
+void multiplication() {
+  //! [product]
+  auto mesh_factory = std::make_unique<mesh::hybrid2d::MeshFactory>(2);
+  auto gmsh_reader = io::GmshReader(std::move(mesh_factory), "mesh.msh");
+
+  // a mesh function which takes the value 1 everywhere
+  auto mf_one = MeshFunctionConstant(1.);
+
+  // a mesh function which represents the radial vector field (x,y)
+  auto mf_radial =
+      MeshFunctionGlobal([](const Eigen::Vector2d& x) { return x; });
+
+  // a matrix valued mesh function ((x,y),(x^2,y^2))
+  auto mf_matrix = MeshFunctionGlobal([](const Eigen::Vector2d& x) {
+    return (Eigen::Matrix2d() << x[0], x[1], x[0] * x[0], x[1] * x[1])
+        .finished();
+  });
+
+  // product of two scalar valued mesh functions:
+  auto p0 = mf_one * MeshFunctionConstant(3.);
+
+  // product of a scalar valued mesh function with a matrix valued one:
+  auto p1 = mf_one * mf_matrix;
+
+  // product of matrix valued with a vector valued mesh function:
+  auto p2 = mf_matrix * mf_radial;  // will be vector valued
+
+  // product of a matrix valued mesh function with itself:
+  auto p3 = mf_matrix * mf_matrix;
+  //! [product]
+}
+
 }  // namespace lf::uscalfe

--- a/lib/lf/base/eigen_tools.h
+++ b/lib/lf/base/eigen_tools.h
@@ -15,17 +15,27 @@
 namespace lf::base {
 
 namespace internal {
-template <class T>
-constexpr T&& constexpr_declval() noexcept;
-struct IsEigenTester {
+
+struct IsEigenMatrixTester {
   template <class SCALAR, int ROWS, int COLS, int OPTIONS, int MAX_ROWS,
             int MAX_COLS>
-  static bool IsEigen(
+  static bool Test(
       const Eigen::Matrix<SCALAR, ROWS, COLS, OPTIONS, MAX_ROWS, MAX_COLS>&,
       int);
 
   template <class T>
-  static float IsEigen(const T&, long);
+  static float Test(const T&, long);
+};
+
+struct IsEigenArrayTester {
+  template <class SCALAR, int ROWS, int COLS, int OPTIONS, int MAX_ROWS,
+            int MAX_COLS>
+  static bool Test(
+      const Eigen::Array<SCALAR, ROWS, COLS, OPTIONS, MAX_ROWS, MAX_COLS>&,
+      int);
+
+  template <class T>
+  static float Test(const T&, long);
 };
 
 }  // namespace internal
@@ -35,7 +45,14 @@ struct IsEigenTester {
  */
 template <class T>
 constexpr bool is_eigen_matrix = std::is_same_v<
-    decltype(internal::IsEigenTester::IsEigen(std::declval<T>(), 0)), bool>;
+    decltype(internal::IsEigenMatrixTester::Test(std::declval<T>(), 0)), bool>;
+
+/**
+ * @brief Check if a given type T is an Eigen::Array
+ */
+template <class T>
+constexpr bool is_eigen_array = std::is_same_v<
+    decltype(internal::IsEigenArrayTester::Test(std::declval<T>(), 0)), bool>;
 
 }  // namespace lf::base
 

--- a/lib/lf/uscalfe/mesh_function_binary.h
+++ b/lib/lf/uscalfe/mesh_function_binary.h
@@ -406,6 +406,7 @@ auto operator-(const A& a, const B& b) {
 
 /**
  * @headerfile lf/uscalfe/uscalfe.h
+ * @relatesalso lf::uscalfe::MeshFunctionBinary
  * @brief Multiply two \ref mesh_function "mesh functions" with each other.
  * @tparam A The type of the lhs \ref mesh_function
  * @tparam B The type of the rhs \ref mesh_function

--- a/lib/lf/uscalfe/mesh_function_binary.h
+++ b/lib/lf/uscalfe/mesh_function_binary.h
@@ -9,7 +9,7 @@
 #ifndef __9bad469d38e04e8ab67391ce50c2c480
 #define __9bad469d38e04e8ab67391ce50c2c480
 
-#include "lf/mesh/mesh_interface.h"
+#include <unsupported/Eigen/KroneckerProduct>
 
 namespace lf::uscalfe {
 
@@ -247,6 +247,103 @@ struct OperatorSubtraction {
   }
 };
 
+struct OperatorMultiplication {
+  // Multiplication of scalar types:
+  template <class U, class V,
+            class = typename std::enable_if<std::is_arithmetic_v<U> &&
+                                            std::is_arithmetic_v<V>>::type>
+  auto operator()(const std::vector<U>& u, const std::vector<V>& v, int
+                  /*unused*/) const {
+    Eigen::Map<const Eigen::Array<U, 1, Eigen::Dynamic>> um(&u[0], 1, u.size());
+    Eigen::Map<const Eigen::Array<U, 1, Eigen::Dynamic>> vm(&v[0], 1, v.size());
+    std::vector<decltype(U(0) * V(0))> result(u.size());
+    Eigen::Map<Eigen::Array<decltype(U(0) * V(0)), 1, Eigen::Dynamic>> rm(
+        &result[0], 1, u.size());
+    rm = um * vm;
+    return result;
+  }
+
+  // multiplication of fixed size eigen matrices
+  template <class S1, int R1, int C1, int O1, int MR1, int MC1, class S2,
+            int R2, int C2, int O2, int MR2, int MC2>
+  auto operator()(const std::vector<Eigen::Matrix<S1, R1, C1, O1, MR1, MC1>>& u,
+                  const std::vector<Eigen::Matrix<S2, R2, C2, O2, MR2, MC2>>& v,
+                  int /*unused*/) const {
+    using scalar_t = decltype(S1(0) * S2(0));
+    if constexpr (R1 != Eigen::Dynamic && C2 != Eigen::Dynamic) {  // NOLINT
+      // The result is fixed size
+      static_assert(C1 == Eigen::Dynamic || R2 == Eigen::Dynamic || C1 == R2,
+                    "#cols of lhs doesn't match #rows of rhs");
+
+      std::vector<Eigen::Matrix<scalar_t, R1, C2>> result(u.size());
+      for (std::size_t i = 0; i < u.size(); ++i) {
+        LF_ASSERT_MSG(u[i].cols() == v[i].rows(),
+                      "#cols of lhs doesn't match #rows of rhs");
+        result[i] = u[i] * v[i];
+      }
+      return result;
+    } else {  // NOLINT
+      // multiply dynamic sized matrices
+      std::vector<Eigen::Matrix<scalar_t, Eigen::Dynamic, Eigen::Dynamic>>
+          result;
+      result.reserve(u.size());
+      for (int i = 0; i < u.size(); ++i) {
+        LF_ASSERT_MSG(u[i].cols() == v[i].rows(),
+                      "#cols of lhs doesn't match #rows of rhs");
+        result.emplace_back(u[i] * v[i]);
+      }
+      return result;
+    }
+  }
+
+  // multiplication of a scalar with matrix
+  template <class U, class S1, int R1, int C1, int O1, int MR1, int MC1,
+            class = std::enable_if_t<std::is_arithmetic_v<U>>>
+  auto operator()(const std::vector<U>& u,
+                  const std::vector<Eigen::Matrix<S1, R1, C1, O1, MR1, MC1>>& v,
+                  int /*unused*/) const {
+    using scalar_t = decltype(u[0] * v[0](0, 0));
+    std::vector<Eigen::Matrix<scalar_t, R1, C1>> result(u.size());
+    if constexpr (R1 != Eigen::Dynamic && C1 != Eigen::Dynamic) {
+      // result is a static sized matrix:
+      Eigen::Map<const Eigen::Array<S1, R1 * C1, Eigen::Dynamic>> vm(
+          v[0].data(), R1 * C1, v.size());
+      Eigen::Map<Eigen::Array<scalar_t, R1 * C1, Eigen::Dynamic>> rm(
+          result[0].data(), R1 * C1, v.size());
+      Eigen::Map<const Eigen::Array<U, 1, Eigen::Dynamic>> um(u.data(), 1,
+                                                              u.size());
+
+      rm = vm * um.template replicate<R1 * C1, 1>();
+    } else {
+      // result is not static sized:
+      for (std::size_t i = 0; i < u.size(); ++i) {
+        result[i] = u[i] * v[i];
+      }
+    }
+    return result;
+  }
+
+  // multiplication of matrix with scalar (other way around)
+  template <class U, class S1, int R1, int C1, int O1, int MR1, int MC1,
+            class = std::enable_if_t<std::is_arithmetic_v<U>>>
+  auto operator()(const std::vector<Eigen::Matrix<S1, R1, C1, O1, MR1, MC1>>& v,
+                  const std::vector<U>& u, int /*unused*/) const {
+    return operator()(u, v, 0);
+  }
+
+  // multiplication of arbitrary types supporting operator*:
+  template <class U, class V>
+  auto operator()(const std::vector<U>& u, const std::vector<V>& v,
+                  long /*unused*/) const {
+    std::vector<decltype(u[0] * v[0])> result;
+    result.reserve(u.size());
+    for (int i = 0; i < result.size(); ++i) {
+      result.emplace_back(u[i] * v[i]);
+    }
+    return result;
+  }
+};
+
 }  // namespace internal
 
 /**
@@ -263,6 +360,11 @@ struct OperatorSubtraction {
  * @note the two \ref mesh_function "mesh functions" `a` and `b` should produce
  * the same type of values, e.g. both should be scalar valued or both
  * matrix/vector valued.
+ *
+ * @note If you want to apply this operator overload to \ref mesh_function "mesh
+ * functions" which do not reside in the `lf::uscalfe` namespace, it will not be
+ * found by Argument Dependent Lookup. You can get around this by explictly
+ * importing the operator overload: `using lf::uscalfe::operator+;`
  *
  * ### Example
  * @snippet mesh_function_binary.cc one_trig
@@ -288,6 +390,11 @@ auto operator+(const A& a, const B& b) {
  * the same type of values, e.g. both should be scalar valued or both
  * matrix/vector valued.
  *
+ * @note If you want to apply this operator overload to \ref mesh_function "mesh
+ * functions" which do not reside in the `lf::uscalfe` namespace, it will not be
+ * found by Argument Dependent Lookup (ADL). You can get around this by
+ * explicitly importing the operator overload: `using lf::uscalfe::operator-;`
+ *
  * ### Example
  * @snippet mesh_function_binary.cc subtract
  */
@@ -295,6 +402,34 @@ template <class A, class B,
           class = std::enable_if_t<isMeshFunction<A> && isMeshFunction<B>>>
 auto operator-(const A& a, const B& b) {
   return MeshFunctionBinary(internal::OperatorSubtraction{}, a, b);
+}
+
+/**
+ * @headerfile lf/uscalfe/uscalfe.h
+ * @brief Multiply two \ref mesh_function "mesh functions" with each other.
+ * @tparam A The type of the lhs \ref mesh_function
+ * @tparam B The type of the rhs \ref mesh_function
+ * @param a the lhs \ref mesh_function
+ * @param b the rhs \ref mesh_function
+ * @return Return `a*b`, i.e. a \ref mesh_function "new mesh function" which
+ * represents the pointwise product of `a` and `b`.
+ *
+ * @note if `A` and `B` are `Eigen::Matrix` valued, the resulting \ref
+ * mesh_function will also be Matrix/Vector valued and will represent the Matrix
+ * product of `a` and `b`.
+ *
+ * @note If you want to apply this operator overload to \ref mesh_function "mesh
+ * functions" which do not reside in the `lf::uscalfe` namespace, it will not be
+ * found by Argument Dependent Lookup (ADL). You can get around this by
+ * explicitly importing the operator overload: `using lf::uscalfe::operator*;`
+ *
+ * ### Example
+ * @snippet mesh_function_binary.cc product
+ */
+template <class A, class B,
+          class = std::enable_if_t<isMeshFunction<A> && isMeshFunction<B>>>
+auto operator*(const A& a, const B& b) {
+  return MeshFunctionBinary(internal::OperatorMultiplication{}, a, b);
 }
 
 }  // namespace lf::uscalfe

--- a/lib/lf/uscalfe/mesh_function_binary.h
+++ b/lib/lf/uscalfe/mesh_function_binary.h
@@ -9,8 +9,6 @@
 #ifndef __9bad469d38e04e8ab67391ce50c2c480
 #define __9bad469d38e04e8ab67391ce50c2c480
 
-#include <unsupported/Eigen/KroneckerProduct>
-
 namespace lf::uscalfe {
 
 /**

--- a/lib/lf/uscalfe/mesh_function_unary.h
+++ b/lib/lf/uscalfe/mesh_function_unary.h
@@ -135,6 +135,20 @@ struct UnaryOpSquaredNorm {
     return result;
   }
 };
+
+struct UnaryOpTranspose {
+  // transpose the eigen matrix
+  template <class S, int R, int C, int O, int MR, int MC>
+  auto operator()(const std::vector<Eigen::Matrix<S, R, C, O, MR, MC>>& u,
+                  int /*unused*/) const {
+    std::vector<Eigen::Matrix<S, C, R>> result(u.size());
+    for (std::size_t i = 0; i < u.size(); ++i) {
+      result[i] = u[i].transpose();
+    }
+    return result;
+  }
+};
+
 }  // namespace internal
 
 /**
@@ -166,6 +180,14 @@ auto operator-(const A& a) {
 template <class A, class = std::enable_if_t<isMeshFunction<A>>>
 auto squaredNorm(const A& a) {
   return MeshFunctionUnary(internal::UnaryOpSquaredNorm{}, a);
+}
+
+template <class A, class = std::enable_if_t<isMeshFunction<A>>>
+auto transpose(const A& a) {
+  static_assert(
+      base::is_eigen_matrix<MeshFunctionReturnType<A>>,
+      "transpose() only supported for Eigen::Matrix valued mesh functions");
+  return MeshFunctionUnary(internal::UnaryOpTranspose{}, a);
 }
 
 }  // namespace lf::uscalfe

--- a/lib/lf/uscalfe/mesh_function_unary.h
+++ b/lib/lf/uscalfe/mesh_function_unary.h
@@ -62,23 +62,58 @@ struct UnaryOpMinus {
     return result;
   }
 
-  // minus in front of a fixed size matrix
-  template <
-      class S, int R, int C, int O, int MR, int MC,
-      class = std::enable_if_t<R != Eigen::Dynamic && C != Eigen::Dynamic>>
+  // minus in front of a Eigen::Matrix
+  template <class S, int R, int C, int O, int MR, int MC>
   auto operator()(const std::vector<Eigen::Matrix<S, R, C, O, MR, MC>>& u,
                   int /*unused*/) const {
-    if (R == 0 || C == 0) {
+    if constexpr (R == 0 || C == 0) {
       // result vector is empty
       return u;
     }
-    Eigen::Map<const Eigen::Matrix<S, 1, Eigen::Dynamic>> um(&u[0](0, 0), 1,
-                                                             u.size() * R * C);
-    std::vector<Eigen::Matrix<S, R, C, O, MR, MC>> result(u.size());
-    Eigen::Map<Eigen::Matrix<S, 1, Eigen::Dynamic>> rm(&result[0](0, 0), 1,
-                                                       u.size() * R * C);
-    rm = -um;
-    return result;
+    if constexpr (R != Eigen::Dynamic && C != Eigen::Dynamic) {
+      // matrix size is known at compile time
+      Eigen::Map<const Eigen::Matrix<S, 1, Eigen::Dynamic>> um(
+          &u[0](0, 0), 1, u.size() * R * C);
+      std::vector<Eigen::Matrix<S, R, C, O, MR, MC>> result(u.size());
+      Eigen::Map<Eigen::Matrix<S, 1, Eigen::Dynamic>> rm(&result[0](0, 0), 1,
+                                                         u.size() * R * C);
+      rm = -um;
+      return result;
+    } else {
+      // matrix size is dynamic
+      std::vector<Eigen::Matrix<S, R, C, O, MR, MC>> result(u.size());
+      for (int i = 0; i < u.size(); ++i) {
+        result[i] = -u[i];
+      }
+      return result;
+    }
+  }
+
+  // minus in front of a Eigen::Array
+  template <class S, int R, int C, int O, int MR, int MC>
+  auto operator()(const std::vector<Eigen::Array<S, R, C, O, MR, MC>>& u,
+                  int /*unused*/) const {
+    if constexpr (R == 0 || C == 0) {
+      // result array is empty
+      return u;
+    }
+    if constexpr (R != Eigen::Dynamic && C != Eigen::Dynamic) {
+      // array size is known at compile time
+      Eigen::Map<const Eigen::Array<S, 1, Eigen::Dynamic>> um(&u[0](0, 0), 1,
+                                                              u.size() * R * C);
+      std::vector<Eigen::Array<S, R, C, O, MR, MC>> result(u.size());
+      Eigen::Map<Eigen::Array<S, 1, Eigen::Dynamic>> rm(&result[0](0, 0), 1,
+                                                        u.size() * R * C);
+      rm = -um;
+      return result;
+    } else {
+      // array size is dynamic
+      std::vector<Eigen::Array<S, R, C, O, MR, MC>> result(u.size());
+      for (int i = 0; i < u.size(); ++i) {
+        result[i] = -u[i];
+      }
+      return result;
+    }
   }
 
   // minus in front of any object that supports the unary operator-
@@ -147,6 +182,17 @@ struct UnaryOpTranspose {
     }
     return result;
   }
+
+  // transpose the eigen array
+  template <class S, int R, int C, int O, int MR, int MC>
+  auto operator()(const std::vector<Eigen::Array<S, R, C, O, MR, MC>>& u,
+                  int /*unused*/) const {
+    std::vector<Eigen::Array<S, C, R>> result(u.size());
+    for (std::size_t i = 0; i < u.size(); ++i) {
+      result[i] = u[i].transpose();
+    }
+    return result;
+  }
 };
 
 }  // namespace internal
@@ -182,10 +228,18 @@ auto squaredNorm(const A& a) {
   return MeshFunctionUnary(internal::UnaryOpSquaredNorm{}, a);
 }
 
+/**
+ * @brief Pointwise transpose of an `Eigen::Matrix` or `Eigen::Array`
+ * @relates lf::uscalfe::MeshFunctionUnary
+ * @tparam A The type of the wrapped mesh function.
+ * @param a The original \ref mesh_function
+ * @return \ref mesh_function representing the pointwise transpose of `a`.
+ */
 template <class A, class = std::enable_if_t<isMeshFunction<A>>>
 auto transpose(const A& a) {
   static_assert(
-      base::is_eigen_matrix<MeshFunctionReturnType<A>>,
+      base::is_eigen_matrix<MeshFunctionReturnType<A>> ||
+          base::is_eigen_array<MeshFunctionReturnType<A>>,
       "transpose() only supported for Eigen::Matrix valued mesh functions");
   return MeshFunctionUnary(internal::UnaryOpTranspose{}, a);
 }

--- a/lib/lf/uscalfe/test/mesh_function_binary_tests.cc
+++ b/lib/lf/uscalfe/test/mesh_function_binary_tests.cc
@@ -43,11 +43,28 @@ auto mfVectorB_dynamic = MeshFunctionGlobal([](const Eigen::Vector2d& x) {
   return Eigen::VectorXd(Eigen::Vector2d(x[0], 2 * x[0]));
 });
 
+auto mfArrayA = MeshFunctionGlobal(
+    [](const Eigen::Vector2d& x) -> Eigen::Array2d { return x.array(); });
+auto mfArrayB =
+    MeshFunctionGlobal([](const Eigen::Vector2d& x) -> Eigen::Array2d {
+      return Eigen::Array2d(x[0], 2 * x[0]);
+    });
+auto mfArrayA_dynamic = MeshFunctionGlobal(
+    [](const Eigen::Vector2d& x) -> Eigen::ArrayXd { return x.array(); });
+auto mfArrayB_dynamic =
+    MeshFunctionGlobal([](const Eigen::Vector2d& x) -> Eigen::ArrayXd {
+      return Eigen::Array2d(x[0], 2 * x[0]);
+    });
+
 auto mfMatrixA =
     MeshFunctionGlobal([](auto x) { return (x * x.transpose()).eval(); });
 auto mfMatrixB = MeshFunctionGlobal([](auto x) -> Eigen::Matrix2d {
   return (Eigen::Matrix2d() << 0, 1, x[0], x[1]).finished();
 });
+auto mfArrayA22 = MeshFunctionGlobal(
+    [](auto x) { return (x * x.transpose()).array().eval(); });
+auto mfArrayB22 = MeshFunctionGlobal(
+    [](auto x) { return (Eigen::Array22d() << 0, 1, x[0], x[1]).finished(); });
 
 auto mfXA = MeshFunctionConstant(X(1));
 auto mfXB = MeshFunctionConstant(X(2));
@@ -67,6 +84,10 @@ TEST(meshFunctionBinary, Addition) {
   checkMeshFunctionEqual(*mesh, mfVectorA + mfVectorB_dynamic, mfVecAdd);
   checkMeshFunctionEqual(*mesh, mfVectorA_dynamic + mfVectorB_dynamic,
                          mfVecAdd);
+  checkMeshFunctionEqual(*mesh, mfArrayA + mfArrayB, mfVecAdd);
+  checkMeshFunctionEqual(*mesh, mfArrayA_dynamic + mfArrayB, mfVecAdd);
+  checkMeshFunctionEqual(*mesh, mfArrayA + mfArrayB_dynamic, mfVecAdd);
+  checkMeshFunctionEqual(*mesh, mfArrayA_dynamic + mfArrayB_dynamic, mfVecAdd);
 
   auto matrixSum = mfMatrixA + mfMatrixB;
   checkMeshFunctionEqual(*mesh, matrixSum, MeshFunctionGlobal([](auto x) {
@@ -89,12 +110,15 @@ TEST(meshFunctionBinary, Subtraction) {
 
   auto mfVecDif = MeshFunctionGlobal(
       [](auto x) { return Eigen::Vector2d(0., x[1] - 2 * x[0]); });
-  auto subVector = mfVectorA - mfVectorB;
   checkMeshFunctionEqual(*mesh, mfVectorA - mfVectorB, mfVecDif);
   checkMeshFunctionEqual(*mesh, mfVectorA_dynamic - mfVectorB, mfVecDif);
   checkMeshFunctionEqual(*mesh, mfVectorA - mfVectorB_dynamic, mfVecDif);
   checkMeshFunctionEqual(*mesh, mfVectorA_dynamic - mfVectorB_dynamic,
                          mfVecDif);
+  checkMeshFunctionEqual(*mesh, mfArrayA - mfArrayB, mfVecDif);
+  checkMeshFunctionEqual(*mesh, mfArrayA_dynamic - mfArrayB, mfVecDif);
+  checkMeshFunctionEqual(*mesh, mfArrayA - mfArrayB_dynamic, mfVecDif);
+  checkMeshFunctionEqual(*mesh, mfArrayA_dynamic - mfArrayB_dynamic, mfVecDif);
 
   auto subMatrix = mfMatrixA - mfMatrixB;
   checkMeshFunctionEqual(*mesh, subMatrix, MeshFunctionGlobal([](auto x) {
@@ -125,6 +149,12 @@ TEST(meshFunctionBinary, Multiplication) {
   checkMeshFunctionEqual(*mesh, mfA * mfVectorA_dynamic, mfVecMult);
   checkMeshFunctionEqual(*mesh, mfVectorA_dynamic * mfA, mfVecMult);
 
+  // mfA * mfArrayA
+  checkMeshFunctionEqual(*mesh, mfA * mfArrayA, mfVecMult);
+  checkMeshFunctionEqual(*mesh, mfArrayA * mfA, mfVecMult);
+  checkMeshFunctionEqual(*mesh, mfA * mfArrayA_dynamic, mfVecMult);
+  checkMeshFunctionEqual(*mesh, mfArrayA_dynamic * mfA, mfVecMult);
+
   // transpose(mfVectorA)*mfVectorB
   auto mfVecMult2 = MeshFunctionGlobal([](auto x) {
     return (Eigen::Matrix<double, 1, 1>() << x[0] * x[0] + 2 * x[1] * x[0])
@@ -145,6 +175,20 @@ TEST(meshFunctionBinary, Multiplication) {
   checkMeshFunctionEqual(
       *mesh, transpose(mfVectorB_dynamic) * mfVectorA_dynamic, mfVecMult2);
 
+  // mfArrayA*mfArrayB
+  auto mfArrayMult = MeshFunctionGlobal(
+      [](auto x) { return Eigen::Array2d(x[0] * x[0], 2 * x[0] * x[1]); });
+  checkMeshFunctionEqual(*mesh, mfArrayA * mfArrayB, mfArrayMult);
+  checkMeshFunctionEqual(*mesh, mfArrayA_dynamic * mfArrayB, mfArrayMult);
+  checkMeshFunctionEqual(*mesh, mfArrayA * mfArrayB_dynamic, mfArrayMult);
+  checkMeshFunctionEqual(*mesh, mfArrayA_dynamic * mfArrayB_dynamic,
+                         mfArrayMult);
+  checkMeshFunctionEqual(*mesh, mfArrayB * mfArrayA, mfArrayMult);
+  checkMeshFunctionEqual(*mesh, mfArrayB_dynamic * mfArrayA, mfArrayMult);
+  checkMeshFunctionEqual(*mesh, mfArrayB * mfArrayA_dynamic, mfArrayMult);
+  checkMeshFunctionEqual(*mesh, mfArrayB_dynamic * mfArrayA_dynamic,
+                         mfArrayMult);
+
   // mfMatrixA * mfVectorA
   auto mfMatrixA_mfVectorA = MeshFunctionGlobal([](auto x) {
     return Eigen::Vector2d(x[0] * x[0] * x[0] + x[0] * x[1] * x[1],
@@ -154,6 +198,15 @@ TEST(meshFunctionBinary, Multiplication) {
   checkMeshFunctionEqual(*mesh, mfMatrixA * mfVectorA_dynamic,
                          mfMatrixA_mfVectorA);
 
+  // mfArrayA22 * mfArrayB22
+  auto mfArrayA22_mfArrayA = MeshFunctionGlobal([](auto x) -> Eigen::Array22d {
+    return (Eigen::Array22d() << 0, x[0] * x[1], x[0] * x[0] * x[1],
+            x[1] * x[1] * x[1])
+        .finished();
+  });
+  checkMeshFunctionEqual(*mesh, mfArrayA22 * mfArrayB22, mfArrayA22_mfArrayA);
+
+  // multiplication of two arbitrary types supporting operator*
   auto xSub = mfXA * mfXB;
   checkMeshFunctionEqual(*mesh, mfXA * mfXB, MeshFunctionConstant(X(2)));
 }

--- a/lib/lf/uscalfe/test/mesh_function_unary_tests.cc
+++ b/lib/lf/uscalfe/test/mesh_function_unary_tests.cc
@@ -92,4 +92,21 @@ TEST(meshFunctionUnary, squaredNorm) {
   }));
 }
 
+TEST(meshFunctionUnary, transpose) {
+  auto reader = io::test_utils::getGmshReader("two_element_hybrid_2d.msh", 2);
+  auto mesh = reader.mesh();
+
+  auto mfVectorT = MeshFunctionGlobal(
+      [](auto x) -> Eigen::Matrix<double, 1, 2> { return x.transpose(); });
+  checkMeshFunctionEqual(*mesh, transpose(mfVector), mfVectorT);
+  checkMeshFunctionEqual(*mesh, transpose(mfVector_dynamic), mfVectorT);
+
+  auto mfRowVectorT = MeshFunctionGlobal(
+      [](auto x) -> Eigen::Vector2d { return Eigen::Vector2d(x[1], -x[0]); });
+  checkMeshFunctionEqual(*mesh, transpose(mfRowVector), mfRowVectorT);
+  checkMeshFunctionEqual(*mesh, transpose(mfRowVector_dynamic), mfRowVectorT);
+
+  checkMeshFunctionEqual(*mesh, transpose(mfMatrix), mfMatrix);
+}
+
 }  // namespace lf::uscalfe::test

--- a/lib/lf/uscalfe/test/mesh_function_unary_tests.cc
+++ b/lib/lf/uscalfe/test/mesh_function_unary_tests.cc
@@ -16,6 +16,7 @@ namespace lf::uscalfe::test {
 
 struct X {
   X() = default;
+
   X(int x) : x_(x) {}
 
   X operator-() const { return X(-x_); }
@@ -33,11 +34,21 @@ auto mfVector = MeshFunctionGlobal([](const Eigen::Vector2d& x) { return x; });
 auto mfVector_dynamic = MeshFunctionGlobal(
     [](const Eigen::Vector2d& x) { return Eigen::VectorXd(x); });
 
+auto mfArray = MeshFunctionGlobal(
+    [](const Eigen::Array2d& x) -> Eigen::Array2d { return x.array(); });
+auto mfArray_dynamic = MeshFunctionGlobal(
+    [](const Eigen::Vector2d& x) -> Eigen::ArrayXd { return x.array(); });
+
 auto mfRowVector =
     MeshFunctionGlobal([](auto x) { return Eigen::RowVector2d(x[1], -x[0]); });
-
 auto mfRowVector_dynamic = MeshFunctionGlobal(
     [](auto x) { return Eigen::MatrixXd(Eigen::RowVector2d(x[1], -x[0])); });
+auto mfRowArray = MeshFunctionGlobal(
+    [](auto x) { return Eigen::Array2d(x[1], -x[0]).transpose().eval(); });
+auto mfRowArray_dynamic =
+    MeshFunctionGlobal([](auto x) -> Eigen::Array<double, 1, Eigen::Dynamic> {
+      return Eigen::Array2d(x[1], -x[0]).transpose().eval();
+    });
 
 auto mfMatrix =
     MeshFunctionGlobal([](auto x) { return (x * x.transpose()).eval(); });
@@ -53,10 +64,11 @@ TEST(meshFunctionUnary, minus) {
     return -x[0] * x[0] - x[1];
   }));
 
-  auto minusVector = -mfVector;
-  checkMeshFunctionEqual(*mesh, minusVector, MeshFunctionGlobal([](auto x) {
-    return (-x).eval();
-  }));
+  auto minusVRef = MeshFunctionGlobal([](auto x) { return (-x).eval(); });
+  checkMeshFunctionEqual(*mesh, -mfVector, minusVRef);
+  checkMeshFunctionEqual(*mesh, -mfVector_dynamic, minusVRef);
+  checkMeshFunctionEqual(*mesh, -mfArray, minusVRef);
+  checkMeshFunctionEqual(*mesh, -mfArray_dynamic, minusVRef);
 
   auto minusMatrix = -mfMatrix;
   checkMeshFunctionEqual(*mesh, minusMatrix, MeshFunctionGlobal([](auto x) {
@@ -100,11 +112,15 @@ TEST(meshFunctionUnary, transpose) {
       [](auto x) -> Eigen::Matrix<double, 1, 2> { return x.transpose(); });
   checkMeshFunctionEqual(*mesh, transpose(mfVector), mfVectorT);
   checkMeshFunctionEqual(*mesh, transpose(mfVector_dynamic), mfVectorT);
+  checkMeshFunctionEqual(*mesh, transpose(mfArray), mfVectorT);
+  checkMeshFunctionEqual(*mesh, transpose(mfArray_dynamic), mfVectorT);
 
   auto mfRowVectorT = MeshFunctionGlobal(
       [](auto x) -> Eigen::Vector2d { return Eigen::Vector2d(x[1], -x[0]); });
   checkMeshFunctionEqual(*mesh, transpose(mfRowVector), mfRowVectorT);
   checkMeshFunctionEqual(*mesh, transpose(mfRowVector_dynamic), mfRowVectorT);
+  checkMeshFunctionEqual(*mesh, transpose(mfRowArray), mfRowVectorT);
+  checkMeshFunctionEqual(*mesh, transpose(mfRowArray_dynamic), mfRowVectorT);
 
   checkMeshFunctionEqual(*mesh, transpose(mfMatrix), mfMatrix);
 }

--- a/lib/lf/uscalfe/test/mesh_function_utils.h
+++ b/lib/lf/uscalfe/test/mesh_function_utils.h
@@ -27,14 +27,22 @@ void checkMeshFunctionEqual(const mesh::Mesh& m, A a, B b, int codim = 0) {
       }
     }
   } else if constexpr (std::is_convertible_v<MeshFunctionReturnType<A>,
-                                             Eigen::MatrixXd>) {
+                                             Eigen::MatrixXd> ||
+                       std::is_convertible_v<MeshFunctionReturnType<A>,
+                                             Eigen::ArrayXd>) {
     for (auto e : m.Entities(codim)) {
       auto ref_el = e->RefEl();
       auto qr = lf::quad::make_QuadRule(ref_el, 5);
       auto vals1 = a(*e, qr.Points());
       auto vals2 = b(*e, qr.Points());
       for (int i = 0; i < vals1.size(); ++i) {
-        EXPECT_LT((vals1[0] - vals2[0]).norm(), 1e-10);
+        ASSERT_EQ(vals1[i].rows(), vals2[i].rows());
+        ASSERT_EQ(vals1[i].cols(), vals2[i].cols());
+        for (int r = 0; r < vals1[i].rows(); ++r) {
+          for (int c = 0; c < vals1[i].cols(); ++c) {
+            EXPECT_LT(std::abs(vals1[i](r, c) - vals2[i](r, c)), 1e-10);
+          }
+        }
       }
     }
   } else {

--- a/lib/lf/uscalfe/uniform_scalar_fe_space.h
+++ b/lib/lf/uscalfe/uniform_scalar_fe_space.h
@@ -67,6 +67,8 @@ class UniformScalarFESpace {
    * functions on quadrilateral cells
    * @param rfs_edge_p shared pointer to layout description for reference shape
    * functions on the edges
+   * @param rfs_point_p shared pointer to layout description for reference shape
+   * functions on the edges
    *
    * The schemes for local shape have to satisfy certain _compatibility
    * conditions_:


### PR DESCRIPTION
This PR add two new ways to build mesh functions out of other mesh functions:
1) We can now multiply two mesh functions with each other. If both mesh functions are matrix valued, this corresponds to a point-wise matrix-matrix product.
2) There is a free function `lf::uscalfe::transpose()` which transpose a (matrix-valued) mesh function pointwise.

@TobiasRohner had a need for 1) in his project. I think it makes sense to put this directly into the library because it is such a general operation.