### PR TITLE
Fix boost

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,8 +3,8 @@ cmake_minimum_required( VERSION 3.10)
 include("cmake/functions.cmake")
 
 HunterGate(
-    URL "https://github.com/cpp-pm/hunter/archive/v0.25.3.tar.gz"
-    SHA1 "0dfbc2cb5c4cf7e83533733bdfd2125ff96680cb"
+    URL "https://github.com/cpp-pm/hunter/archive/ead00a62a9a05d36f3d376889360b379d9046ba1.tar.gz"
+    SHA1 "7456937b43b9071498ba521fda9daafd931baa4a"
     LOCAL # use cmake/Hunter/config.cmake
 )
 

--- a/cmake/Hunter/config.cmake
+++ b/cmake/Hunter/config.cmake
@@ -1,4 +1,12 @@
 # This file specifies additional data for the dependencies that are imported via hunter
-hunter_config(Boost VERSION 1.78.0)
+
+
+hunter_config(Boost 
+  VERSION 1.86.0
+  URL "https://archives.boost.io/release/1.86.0/source/boost_1_86_0.tar.bz2"
+  SHA1
+  fd0d26a7d5eadf454896942124544120e3b7a38f
+)
+
 hunter_config(Eigen VERSION 3.4.0)
 hunter_config(GTest VERSION 1.11.0)


### PR DESCRIPTION
- Uses latest prerelease of hunter (which doesn't use jfrog anymore as a download server): https://github.com/cpp-pm/hunter/issues/770#issuecomment-2607901591
- Uses Boost 1.86 which should better support modern build chains.