### PR TITLE
Moved QR snippets

### DIFF
--- a/doc/doxygen/CMakeLists.txt
+++ b/doc/doxygen/CMakeLists.txt
@@ -10,7 +10,7 @@ if(DOXYGEN_FOUND)
   
   OPTION(LF_DOX_EXTRACT_PRIVATE "Equals the value value EXTRACT_PRIVATE of doc/doxygen/doxyfile. Set this to On in order to also generate doxygen documentation of private members." ON)
   OPTION(LF_DOX_INCLUDE_PROJECTS "Set this to true to include all the projects in the ./projects folder in the doxygen documentation." OFF)
-  OPTION(LF_DOX_ENABLE_FILTERS "If this is set to false, @lref{} statements in doxygen documentation are not translated into formatted latex label." ON)
+  OPTION(LF_DOX_ENABLE_FILTERS "If this is set to false, filters (see filters/ directory) are not run" ON)
 
   
   if(LF_DOX_EXTRACT_PRIVATE)

--- a/doc/doxygen/pages/quick_reference_bc.md
+++ b/doc/doxygen/pages/quick_reference_bc.md
@@ -15,9 +15,7 @@ To fix degrees of freedom (DoFs) on the boundary, we can use the functions `lf::
 
 We can obtain the boundary flags as a [MeshDataSet](@ref mesh_data_sets) using:
 
-```cpp
-auto bd_flags = lf::mesh::utils::flagEntitiesOnBoundary(dofh.Mesh(), 2);
-```
+@snippet{trimleft} quick_reference/qr_bc_snippets.cpp bc Overview
 
 The second argument is the co-dimension of the entities we are interested in. To fix all DoFs on the boundary (including those associated with edges and cells), omit the second argument.
 
@@ -25,20 +23,11 @@ The second argument is the co-dimension of the entities we are interested in. To
 
 Let \f$g\f$ be a function defining the values on the boundary. To get the function values of \f$g\f$ at the boundary nodes, wrap it in a MeshFunction:
 
-```cpp
-auto mf_g = lf::mesh::utils::MeshFunctionGlobal(g);
-
-std::vector<std::pair<bool, scalar_t>> boundary_val = 
-    lf::fe::InitEssentialConditionFromFunction(*fe_space, bd_flags, mf_g);
-```
+@snippet{trimleft} quick_reference/qr_bc_snippets.cpp bc One function on the whole boundary
 
 This returns a `std::vector<std::pair<bool, scalar_t>>`. To create our selector:
 
-```cpp
-auto selector = [&](unsigned int dof_idx) -> std::pair<bool, double> {
-    return boundary_val[dof_idx];
-};
-```
+@snippet{trimleft} quick_reference/qr_bc_snippets.cpp bc One function on the whole boundary 0
 
 If \f$g\f$ has different definitions on different parts of the boundary (e.g., \f$g = 0\f$ on \f$\gamma_0\f$ and \f$g = 1\f$ on
 \f$\gamma_1\f$), try to express \f$g\f$ as a lambda function with an if-else statement.
@@ -47,34 +36,19 @@ If \f$g\f$ has different definitions on different parts of the boundary (e.g., \
 
 The selector becomes:
 
-```cpp
-auto selector = [&](unsigned int dof_idx) -> std::pair<bool, double> {
-    if (bd_flags[dof_idx]) {
-        return std::make_pair(true, boundary_value);
-    } else {
-        return std::make_pair(false, 0.0); // value irrelevant
-    }
-};
-```
+@snippet{trimleft} quick_reference/qr_bc_snippets.cpp bc Constant value on the boundary
 
 ## BC only on part of the boundary {#part_of_boundary}
 
 We need to create our own `bd_flags`. Initialize a `MeshDataSet` with default value `false`:
 
-```cpp
-lf::mesh::utils::AllCodimMeshDataSet<bool> bd_flags(mesh_p, false);
-```
+@snippet{trimleft} quick_reference/qr_bc_snippets.cpp bc BC only on part of the boundary
 
 Then loop over nodes and edges separately and set `bd_flags` to true for the nodes/edges where the boundary condition should be applied.
 
-```cpp
-for (const auto& edge : fe_space->Mesh()->Entities(1)) {
-    if (...) bd_flags(*edge) = true;
-}
+@snippet{trimleft} quick_reference/qr_bc_snippets.cpp bc BC only on part of the boundary 0
 
-for (const auto& node : fe_space->Mesh()->Entities(2)) {
-    // 
-    ...
-}
-```
 
+## Example (Essential boundary conditions) {#example}
+
+@snippet{trimleft} fe_tools.cc InitEssentialConditionFromFunction

--- a/doc/doxygen/pages/quick_reference_dofh.md
+++ b/doc/doxygen/pages/quick_reference_dofh.md
@@ -33,32 +33,11 @@ LehrFEM++ provides two implementations of DOF handlers:
 
 A `DynamicFEDofHandler` can be initialized with a function that returns the number of DOFs associated with a given entity.
 
-```cpp
-const std::shared_ptr<const lf::mesh::Mesh> mesh_p =
-      lf::mesh::test_utils::GenerateHybrid2DTestMesh(1);
-
-auto func = [](const lf::mesh::Entity& e) {
-  // return number of dofs associated with e
-  return 1;
-};
-
-lf::assemble::DynamicFEDofHandler dofh(mesh_p, func);
-```
+@snippet{trimleft} quick_reference/qr_dofh_snippets.cpp dofh DynamicFEDofHandler
 
 ### UniformFEDofHandler
 
-```cpp
-// Generate a simple test mesh
-const std::shared_ptr<const lf::mesh::Mesh> mesh_p =
-    lf::mesh::test_utils::GenerateHybrid2DTestMesh(1);
-
-// Initialize a DofHandler for p=2 Lagrange FE
-lf::assemble::UniformFEDofHandler dofh(mesh_p,
-                                        {{lf::base::RefEl::kPoint(), 1},
-                                        {lf::base::RefEl::kSegment(), 1},
-                                        {lf::base::RefEl::kTria(), 0},
-                                        {lf::base::RefEl::kQuad(), 1}});
-```
+@snippet{trimleft} quick_reference/qr_dofh_snippets.cpp dofh UniformFEDofHandler
 
 For example, in a second-order Lagrange FE space (as shown in the code above):
 
@@ -83,37 +62,18 @@ The key methods provided by the `DofHandler` interface are:
 
 - `NumDofs()`: Returns the total number of global DOFs. See also @lref_link{par:betldofmap}.
 
-  ```cpp
-  unsigned num_dofs = dofh.NumDofs();
-  ```
+@snippet{trimleft} quick_reference/qr_dofh_snippets.cpp dofh Key Methods
 
 - `NumLocalDofs(const lf::mesh::Entity &)`: Returns the number of DOFs associated with a particular geometric entity.  See also @lref_link{par:betldofmap}.
   
-  ```cpp
-  const lf::mesh::Entity* e = mesh_p->EntityByIndex(0, 0);
-
-  unsigned num_local_dofs = dofh.NumLocalDofs(*e);
-  ```
+@snippet{trimleft} quick_reference/qr_dofh_snippets.cpp dofh Key Methods 0
 - `GlobalDofIndices(const lf::mesh::Entity &)`: Returns the global indices of DOFs associated with a given entity.  See also @lref_link{par:betldofmap}.
 
-  ```cpp
-  const lf::mesh::Entity* e = mesh_p->EntityByIndex(0, 0);
-
-  std::span<const lf::assemble::gdof_idx_t> idx = dof2.GlobalDofIndices(*e);
-
-  for (auto i : idx) {
-    std::cout << i << " ";
-  } // -> prints the global indices of DOFs associated with the entity
-
-  ```
+@snippet{trimleft} quick_reference/qr_dofh_snippets.cpp dofh Key Methods 1
 
 - `NumInteriorDofs(const lf::mesh::Entity &)`: Specifies how many DOFs are associated with an entity’s interior.  See also @lref_link{par:betldofmap}.
 
-  ```cpp
-  const lf::mesh::Entity* e = mesh_p->EntityByIndex(0, 0);
-
-  unsigned num_int_dofs = dofh.NumInteriorDofs(*e);
-  ```
+@snippet{trimleft} quick_reference/qr_dofh_snippets.cpp dofh Key Methods 2
 
 ## Example Code
 An example of using a DofHandler to print information about local-to-global mappings in LehrFEM++:

--- a/doc/doxygen/pages/quick_reference_fe_space.md
+++ b/doc/doxygen/pages/quick_reference_fe_space.md
@@ -19,19 +19,7 @@ The `lf::fe` namespace provides a general interface for scalar finite element sp
 
 A special case of the general scalar finite element space is a **Hierarchic Scalar Finite Element Space**, implemented by `lf::fe::HierarchicScalarFESpace`. Hierarchic FE spaces assign a polynomial degree for the shape functions to each mesh entity. They can easily be constructed from a mesh and a function mapping mesh entities to polynomial degrees.
 
-```cpp
-// generate a simple test mesh
-std::shared_ptr<lf::mesh::Mesh> mesh_p =
-      lf::mesh::test_utils::GenerateHybrid2DTestMesh(1);
-
-// define a polynomial degree function
-auto degree = [](const lf::mesh::Entity &entity) -> unsigned {
-  return 2; // all entities have degree 2 -> equivalent to O2 Lagrangian FESpace
-};
-
-// init HierarchicScalarFESpace on mesh_p
-lf::fe::HierarchicScalarFESpace<double> fe_space(mesh_p, degree);
-```
+@snippet{trimleft} quick_reference/qr_fe_space_snippets.cpp fe_space Hierarchic Scalar Finite Element Space
 
 ## Uniform Finite Element Space (lf::uscalfe) {#uniform_finite_element_spaces}
 
@@ -47,11 +35,4 @@ LehrFEM++ provides convenience classes for constructing order 1, 2, and 3 Lagran
 - `lf::uscalfe::FeSpaceLagrangeO2`: Quadratic Lagrangian Finite Element space.
 - `lf::uscalfe::FeSpaceLagrangeO3`: Cubic Lagrangian Finite Element space.
 
-```cpp
-// generate a simple test mesh
-std::shared_ptr<lf::mesh::Mesh> mesh_p =
-      lf::mesh::test_utils::GenerateHybrid2DTestMesh(1);
-
-// init O1 Lagrangian finite element space on mesh_p
-lf::uscalfe::FeSpaceLagrangeO1<double> fe_space(mesh_p);
-```
+@snippet{trimleft} quick_reference/qr_fe_space_snippets.cpp fe_space Lagrangian Finite Element Spaces

--- a/doc/doxygen/pages/quick_reference_geometry.md
+++ b/doc/doxygen/pages/quick_reference_geometry.md
@@ -21,56 +21,23 @@ More details and mathematical background can be found in @lref_link{sec:parmFE}.
 
 To get the geometry of an entity:
 
-```cpp
-for (const lf::mesh::Entity* entity : mesh.Entities(codim)) {
-    // Get the geometry of an entity
-    const lf::geometry::Geometry* geometry = entity->Geometry();
-}
-```
+@snippet{trimleft} quick_reference/qr_geometry_snippets.cpp geometry Geometry Interface
 
 ### Utility Functions {#geometry_utility}
 
 A number of convenience functions are provided by the `Geometry` class.
 
-```cpp
-const lf::geometry::Geometry* geometry = entity->Geometry();
-
-// Get the volume of an entity (for edges length, for triangles area, etc.)
-double v = lf::geometry::Volume(*geometry);
-
-// Get the corners of an entity as a dxn matrix
-// where d is the dimension of physical space, and n the number of corners.
-// (for edges 2 corners, for triangles 3 corners, etc.)
-Eigen::MatrixXd corners = lf::geometry::Corners(*geometry);
-```
+@snippet{trimleft} quick_reference/qr_geometry_snippets.cpp geometry Utility Functions
 
 In addition, we can test for some properties of the geometry:
 
-```cpp
-// Test if geometry is a non-degenerate bilinear quadrilateral (corners matrix with 4 cols)
-bool is_not_deg = lf::geometry::assertNonDegenerateQuad(corners);
-
-// Test if geometry is a non-degenerate triangle (corners matrix with 3 cols)
-bool is_not_deg = lf::geometry::assertNonDegenerateTriangle(corners);
-```
+@snippet{trimleft} quick_reference/qr_geometry_snippets.cpp geometry Utility Functions 0
 
 ## Geometry Methods {#geometry_methods}
 
 Objects implementing the `lf::geometry::Geometry` interface provide the following methods:
 
-```cpp
-// Dimension of the local coordinate system
-unsigned dim_local = geometry->DimLocal(); 
-
-// Dimension of the physical coordinate system
-unsigned dim_global = geometry->DimGlobal();
-
-// Get the reference element for the geometry
-lf::base::RefEl ref_el = geometry->RefEl();
-
-// Check if mapping is affine
-bool is_affine = geometry->isAffine();
-```
+@snippet{trimleft} quick_reference/qr_geometry_snippets.cpp geometry Geometry Methods
 
 ## Transformations and Mappings {#transformations}
 
@@ -83,15 +50,7 @@ This part is discussed in detail in @lref_link{sec:parmFE}. Usage of the followi
 
 The `lf::geometry::Geometry` class provides the `lf::geometry::Geometry::Global` method to map points from local to global coordinates. In LehrFEM++, `local` points generally refer to points on the reference element.
 
-```cpp
-// Define two point on the reference element (local).
-Eigen::MatrixXd local_points(2, 2);
-local_points << 0.1, 0.5,
-                0.6, 0.2;
-
-// Map the points from the local into the global space.
-Eigen::MatrixXd global = geometry->Global(local_points);
-```
+@snippet{trimleft} quick_reference/qr_geometry_snippets.cpp geometry Global
 
 ![Mapping of points from local to global coordinates](manim/mapping_global.gif)
 
@@ -105,10 +64,7 @@ The method `lf::geometry::Geometry::IntegrationElement` computes the integration
 
 for each point in `points` as an `Eigen::VectorXd`.
 
-```cpp
-// Compute the integration element for each point in points
-Eigen::VectorXd integration_element = geometry->IntegrationElement(local_points);
-```
+@snippet{trimleft} quick_reference/qr_geometry_snippets.cpp geometry IntegrationElement
 
 > [!note]
 > The following two methods return a matrix for each evaluated point. For efficiency reasons, the returned matrices are horizontally stacked. The number of rows corresponds to the dimension of the global coordinate system.
@@ -117,19 +73,11 @@ Eigen::VectorXd integration_element = geometry->IntegrationElement(local_points)
 
 The method `lf::geometry::Geometry::Jacobian` computes the Jacobian matrix \f$ D\Phi(\hat{x}) \f$ for each point in `points`.
 
-```cpp
-// Compute the Jacobian matrix for each point in points
-Eigen::MatrixXd jacobian = geometry->Jacobian(local_points);
-```
+@snippet{trimleft} quick_reference/qr_geometry_snippets.cpp geometry Jacobian
 
 The Jacobian evaluated at every point is itself a matrix of size `dim_global x num_points`. The JacobianInverseGramian evaluated at every point is a matrix of size `dim_local x (dim_global * num_points)`. To access the Jacobian at a specific point, use the following code:
 
-```cpp
-unsigned dim_global = geometry->DimGlobal();
-unsigned dim_local = geometry->DimLocal();
-// Access the Jacobian matrix for the n-th point (starting at 0)
-Eigen::MatrixXd jacobian_n = jacobian.block(0, n * dim_local, dim_global, dim_local);
-```
+@snippet{trimleft} quick_reference/qr_geometry_snippets.cpp geometry Jacobian 0
 
 If `dim_local == dim_global == 2` and we pass three points for evaluation, [Geometry::Jacobian](@ref lf::geometry::Geometry::Jacobian) returns a \f$ 2 \times 6 \f$ matrix:
 
@@ -137,22 +85,13 @@ If `dim_local == dim_global == 2` and we pass three points for evaluation, [Geom
 
 To access the Jacobian for the second point, we can use [Eigen block access](https://eigen.tuxfamily.org/dox/group__TutorialBlockOperations.html):
 
-```cpp
-// Access 2x2 Jacobian matrix starting at row 0 and column 2
-Eigen::MatrixXd jacobian_2 = jacobian.block(0, 2, 2, 2);
-```
+@snippet{trimleft} quick_reference/qr_geometry_snippets.cpp geometry Jacobian 1
 
 ### JacobianInverseGramian {#jacobian_inverse_gramian}
 
 The method `lf::geometry::Geometry::JacobianInverseGramian` computes the inverse of the JacobianInverseGramian matrix for each point in `points`. Details can be found in @lref_link{rem:jti} and the [method docs](@ref lf::geometry::Geometry::JacobianInverseGramian). Similarly to [Geometry::Jacobian](@ref lf::geometry::Geometry::Jacobian), it also returns a horizontally stacked matrix. Individual matrices can be accessed using `Eigen` block. 
 
-```cpp
-// Compute the inverse of the Jacobian matrix for each point in points
-Eigen::MatrixXd jacobian_inv = geometry->JacobianInverseGramian(local_points);
-
-// Access the JacobianInverseGramian matrix for the n-th point (starting at 0)
-Eigen::MatrixXd jacobian_inv_n = jacobian_inv.block(0, n * dim_local, dim_global, dim_local);
-```
+@snippet{trimleft} quick_reference/qr_geometry_snippets.cpp geometry JacobianInverseGramian
 
 <!-- Next and previous buttons -->
 <div class="section_buttons">

--- a/doc/doxygen/pages/quick_reference_mesh.md
+++ b/doc/doxygen/pages/quick_reference_mesh.md
@@ -13,32 +13,15 @@
 
 Meshes in LehrFEM++ are generally managed through shared pointers. A simple test mesh can be generated using the following code snippet:
 
-```cpp
-// Generate a simple test mesh
-const std::shared_ptr<const lf::mesh::Mesh> mesh_ptr =
-    lf::mesh::test_utils::GenerateHybrid2DTestMesh(1);
-
-// Auto can be used to simplify the type declaration
-auto mesh_ptr = lf::mesh::test_utils::GenerateHybrid2DTestMesh(1);
-```
+@snippet{trimleft} quick_reference/qr_mesh_snippets.cpp mesh Overview
 
 ## Mesh Access {#mesh_access}
 
-```cpp
-// create a pointer to the mesh
-const std::shared_ptr<const lf::mesh::Mesh> mesh_p = lf::mesh::test_utils::GenerateHybrid2DTestMesh(1);
-```
+@snippet{trimleft} quick_reference/qr_mesh_snippets.cpp mesh Mesh Access
 
 The mesh object can be accessed through the pointer `mesh_p` (will be used throughout this page). The mesh object provides access to the following information:
 
-```cpp
-// Access number of cells
-unsigned num_entities = mesh_p->NumEntities(0);
-
-// Access number of edges
-unsigned num_nodes = mesh_p->NumEntities(1);
-
-```
+@snippet{trimleft} quick_reference/qr_mesh_snippets.cpp mesh Mesh Access 0
 
 ## Entities {#entities}
 
@@ -51,58 +34,19 @@ Entities implement the lf::mesh::Entity interface and are the building blocks of
 
 A complete list can be found in the inheritance diagram of the lf::mesh::Entity interface class. Entities can be accessed by index or by iterating over all entities of a given co-dimension.
 
-```cpp
-// Get entity pointer by index from a mesh
-const lf::mesh::Entity* entity = mesh_p->EntityByIndex(0, 0);
-
-// Iterate over all entities of co-dimension 0 (cells)
-for (const lf::mesh::Entity* cell : mesh_p->Entities(0)) {
-    // Do something with entity e.g.: print index of cell
-    std::cout << mesh_p->Index(*cell) << std::endl;
-}
-```
+@snippet{trimleft} quick_reference/qr_mesh_snippets.cpp mesh Entities
 
 Entities have a number of properties that can be accessed:
 
-```cpp
-// Get the co-dimension of the entity
-unsigned codim = entity->Codim();
-
-// Get the geometry of the entity, more details can be found 
-// in the Geometry Quick reference
-const lf::geometry::Geometry* geometry = entity->Geometry();
-
-// Get the reference element of the entity (e.g. the unit triangle for a general triangle)
-lf::base::RefEl ref_el = entity->RefEl();
-```
+@snippet{trimleft} quick_reference/qr_mesh_snippets.cpp mesh Entities 0
 
 It is also possible to access sub-entities of an entity, see lf::mesh::Entity::SubEntities for details.
 
-```cpp
-// Return all sub entities of this entity that have the given 
-// co-dimension (w.r.t. this entity!)
-// For example, for a cell, the sub-entities of co-dimension 1
-std::span<const lf::mesh::Entity* const> sub_entities =
-      entity->SubEntities(1);
-
-// If you require a vector of sub-entities, you can use the following code snippet
-std::vector<const lf::mesh::Entity*> sub_entities_vec{
-    entity->SubEntities(1).begin(), entity->SubEntities(1).end()};
-
-```
+@snippet{trimleft} quick_reference/qr_mesh_snippets.cpp mesh Entities 1
 
 A slightly more nuanced concept is the relative orientation of sub-entities of the next higher co-dimension. A detailed explanation can be found in the @lref_link{rem:ori}.
 
-```cpp
-// return span of relative orientations of sub-entities of the next higher co-dimension.
-std::span<const lf::mesh::Orientation> orientations =
-      entity->RelativeOrientations();
-
-// If you require a vector of orientations, you can use the following code snippet
-std::vector<lf::mesh::Orientation> orientations_vec{
-      entity->RelativeOrientations().begin(),
-      entity->RelativeOrientations().end()};
-```
+@snippet{trimleft} quick_reference/qr_mesh_snippets.cpp mesh Entities 2
 
 ## Mesh Data Sets {#mesh_data_sets}
 
@@ -111,34 +55,14 @@ Mesh data sets are used to store data with entities of the mesh. A fe common use
 - Flags that mark boundary entities.
 - Material parameters for mesh elements (codim=0)
 
-```cpp
-// Create a mesh data set storing boolean values for each entity
-lf::mesh::utils::AllCodimMeshDataSet<bool> mesh_data_set =
-      lf::mesh::utils::AllCodimMeshDataSet<bool>(mesh_p);
-
-// Create a MDS storing boolean values for each entity of co-dimension 1 (edges)
-lf::mesh::utils::CodimMeshDataSet<bool> mesh_data_set_edges =
-      lf::mesh::utils::CodimMeshDataSet<bool>(mesh_p, 1);
-
-// Mesh data sets can be initialized with a default value
-lf::mesh::utils::AllCodimMeshDataSet<bool> mesh_data_set_2 =
-      lf::mesh::utils::AllCodimMeshDataSet<bool>(mesh_p, false);
-
-// Access a (modifiable) value associated with an entity
-const lf::mesh::Entity* entity = mesh_p->EntityByIndex(0, 0);
-bool value = mesh_data_set(*entity);
-```
+@snippet{trimleft} quick_reference/qr_mesh_snippets.cpp mesh Mesh Data Sets
 
 In this example, a mesh data set is created that stores boolean values for each entity/edge of the mesh.
 
 To flag all entities on the boundary of the mesh, the following code snippet can be used:
 
 
-```cpp
-// Create MeshDataSet storing boolean values for each entity indicating if the entity is on the boundary
-lf::mesh::utils::AllCodimMeshDataSet<bool> bd_flags{
-      lf::mesh::utils::flagEntitiesOnBoundary(mesh_p)};
-```
+@snippet{trimleft} quick_reference/qr_mesh_snippets.cpp mesh Mesh Data Sets 0
 
 See also [Quick Reference - Boundary Conditions](@ref quick_reference_bc) for more details on boundary conditions.
 
@@ -158,23 +82,7 @@ For efficiency reasons the evaluation points are passed to mesh functions as the
 
 on a cell.
 
-```cpp
-// Define a lambda function that takes a point in the reference element of an entity and returns a value
-auto alpha = [](Eigen::Vector2d x) -> double {
-    return 0.5 * x.norm();
-};
-
-// Wrap the lambda function in a MeshFunctionGlobal object
-// Type of mesh function template parameter is automatically deduced
-lf::mesh::utils::MeshFunctionGlobal mesh_function = lf::mesh::utils::MeshFunctionGlobal(alpha);
-
-// Evaluate the mesh function on a cell
-const lf::mesh::Entity* cell = mesh_p->EntityByIndex(0, 0);
-std::vector<double> values = mesh_function(*cell, Eigen::Vector2d{0.5, 0.5});
-
-// We only asked for one point, so the vector has only one entry
-std::cout << "Value: " << values[0] << std::endl; // Value: 0.790569
-```
+@snippet{trimleft} quick_reference/qr_mesh_snippets.cpp mesh Mesh Functions
 
 There are is also a short-hand for mesh functions that are constant everywhere on the mesh: lf::mesh::utils::MeshFunctionConstant.
 
@@ -197,23 +105,11 @@ The standard ways to create a Mesh object are:
 
 2. **Calling LehrFEM++'s generator of test meshes** lf::mesh::test_utils::GenerateHybrid2DTestMesh(). The method provides access to a number of simple predefined test meshes. The following code snippet demonstrates how to generate a simple test mesh:
 
-    ```cpp
-    // Generate a simple test mesh
-    std::shared_ptr<lf::mesh::Mesh> mesh_p = lf::mesh::test_utils::GenerateHybrid2DTestMesh(1);
-    ```
+@snippet{trimleft} quick_reference/qr_mesh_snippets.cpp mesh Mesh Creation
 
 3. **Reading a mesh from file**: see lf::io::GmshReader, and invoking lf::io::GmshReader::mesh(). The following code snippet demonstrates how to read a mesh from a file:
 
-    ```cpp
-    // Read a mesh from a file
-    std::unique_ptr<lf::mesh::hybrid2d::MeshFactory> mesh_factory =
-      std::make_unique<lf::mesh::hybrid2d::MeshFactory>(2);
-    lf::io::GmshReader gmsh_reader =
-        lf::io::GmshReader(std::move(mesh_factory), "triangle.msh");
-    
-    // Get pointer to the mesh
-    std::shared_ptr<lf::mesh::Mesh> mesh = gmsh_reader.mesh();
-    ```
+@snippet{trimleft} quick_reference/qr_mesh_snippets.cpp mesh Mesh Creation 0
 
 4. **Refining an existing mesh**, see lf::refinement::MeshHierarchy or the short example below.
 
@@ -223,61 +119,13 @@ LehrFEM++ provides a number of mesh refinement tools included in the lf::refinem
 
 Mesh refinement using LehrFEM++ is covered in @lref_link{ss:ref} and heavily used in @lref_link{cha:cvg}.
 
-```cpp
-std::shared_ptr<lf::mesh::Mesh> mesh_p = lf::mesh::test_utils::GenerateHybrid2DTestMesh(0);
-// Generate mesh hierarchy by uniform refinement with 6 levels
-
-std::shared_ptr<lf::refinement::MeshHierarchy> mesh_seq_p{
-    lf::refinement::GenerateMeshHierarchyByUniformRefinemnt(mesh_p, 3)};
-
-// Access the mesh at level 3
-std::shared_ptr<lf::mesh::Mesh> mesh_level_3 = mesh_seq_p->getMesh(3);
-
-// We can refine a mesh further by calling
-mesh_seq_p->RefineRegular();
-
-// Access the mesh at level 4
-std::shared_ptr<lf::mesh::Mesh> mesh_level_4 = mesh_seq_p->getMesh(4);
-```
+@snippet{trimleft} quick_reference/qr_mesh_snippets.cpp mesh Mesh Refinement
 
 ### Mesh Builder {#mesh_builder}
 
 Meshes can be built 'manually' using the lf::mesh::MeshFactory class. It follows a [builder pattern](https://refactoring.guru/design-patterns/builder) and allows the user to add entities to the mesh. 
 
-```cpp
-// builder for a hybrid mesh in a world of dimension 2
-std::shared_ptr<lf::mesh::hybrid2d::MeshFactory> mesh_factory =
-    std::make_shared<lf::mesh::hybrid2d::MeshFactory>(2);
-
-// Add points (needs to be done before adding entities)
-mesh_factory->AddPoint(Eigen::Vector2d{0, 0});    // (0)
-mesh_factory->AddPoint(Eigen::Vector2d{1, 0});    // (1)
-mesh_factory->AddPoint(Eigen::Vector2d{1, 1});    // (2)
-mesh_factory->AddPoint(Eigen::Vector2d{0, 1});    // (3)
-mesh_factory->AddPoint(Eigen::Vector2d{0.5, 1});  // (4)
-
-// Add a triangle
-// First set the coordinates of its nodes:
-Eigen::MatrixXd nodesOfTria(2, 3);
-nodesOfTria << 1, 1, 0.5, 0, 1, 1;
-mesh_factory->AddEntity(
-    lf::base::RefEl::kTria(),  // we want a triangle
-    std::array<lf::mesh::Mesh::size_type, 3>{
-        {1, 2, 4}},  // indices of the nodes
-    std::make_unique<lf::geometry::TriaO1>(nodesOfTria));  // node coords
-
-// Add a quadrilateral
-Eigen::MatrixXd nodesOfQuad(2, 4);
-nodesOfQuad << 0, 1, 0.5, 0, 0, 0, 1, 1;
-mesh_factory->AddEntity(
-    lf::base::RefEl::kQuad(), // we want a quadrilateral
-    std::array<lf::mesh::Mesh::size_type, 4>{
-        {0, 1, 4, 3}}, // indices of the nodes
-    std::make_unique<lf::geometry::QuadO1>(nodesOfQuad)); // node coords
-
-// Build the mesh
-std::shared_ptr<lf::mesh::Mesh> mesh = mesh_factory->Build();
-```
+@snippet{trimleft} quick_reference/qr_mesh_snippets.cpp mesh Mesh Builder
 
 We can also use the mesh builder to create a tensor product mesh. LehrFEM++ provides a number of mesh builders for different types of meshes.
 
@@ -287,20 +135,7 @@ We can also use the mesh builder to create a tensor product mesh. LehrFEM++ prov
 
 The following code snippet demonstrates how to create a 100x100 tensor product mesh of triangles:
 
-```cpp
-  // Create a LehrFEM++ square tensor product mesh
-  lf::mesh::utils::TPTriagMeshBuilder builder(
-      std::make_unique<lf::mesh::hybrid2d::MeshFactory>(2));
-
-  // Set mesh parameters following the builder pattern
-  // Domain is the unit square
-  builder.setBottomLeftCorner(Eigen::Vector2d{0, 0})
-      .setTopRightCorner(Eigen::Vector2d{99, 99})
-      .setNumXCells(100)
-      .setNumYCells(100);
-
-  std::shared_ptr<lf::mesh::Mesh> mesh_p = builder.Build();
-```
+@snippet{trimleft} quick_reference/qr_mesh_snippets.cpp mesh Mesh Builder 0
 
 
 <!-- Next and previous buttons -->

--- a/doc/doxygen/pages/quick_reference_quad.md
+++ b/doc/doxygen/pages/quick_reference_quad.md
@@ -14,50 +14,19 @@ LehrFEM++ provides a number of quadrature rules for the numerical integration of
 # Working with Quadrature Rules
 The `quad` namespace has some useful functions for instantiating quadrature rules for a given reference element. The following code snippet shows how to get a quadrature rule for a triangle of degree >= 3 using `lf::quad::make_QuadRule`.
 
-```cpp
-auto ref_tria = lf::base::RefEl::kTria();
-
-lf::quad::QuadRule qr = lf::quad::make_QuadRule(ref_tria, 3);
-```
+@snippet{trimleft} quick_reference/qr_quad_snippets.cpp quad Working with Quadrature Rules
 
 It is also possible to get a quadrature rule which only uses the nodes of the reference element to approximate the integral using `lf::quad::make_QuadRuleNodal`.
 
-```cpp
-lf::quad::QuadRule qr = lf::quad::make_QuadRuleNodal(ref_tria);
-```
+@snippet{trimleft} quick_reference/qr_quad_snippets.cpp quad Working with Quadrature Rules 0
 
 Another possibility is to define a quadrature rule by specifying the nodes and weights manually. This can be done using the `lf::quad::QuadRule` constructor.
 
-```cpp
-Eigen::MatrixXd points(2, 3);
-points << 0.166667, 0.666667, 0.166667,
-          0.166667, 0.166667, 0.666667;
-
-Eigen::Vector3d weights;
-weights << 0.166667, 0.166667, 0.166667;
-
-auto qr = lf::quad::QuadRule(ref_tria, points, weights, 2);
-```
+@snippet{trimleft} quick_reference/qr_quad_snippets.cpp quad Working with Quadrature Rules 1
 
 Lastly LehrFEM++ also provides a few more specialized quadrature rules. A list can be found on the [Quadrature Rules Namespace](@ref lf::quad) page.
 
 # Using a Quadrature Rule
 
-```cpp
-auto ref_tria = lf::base::RefEl::kTria();
-
-lf::quad::QuadRule qr = lf::quad::make_QuadRule(ref_tria, 3);
-
-// Get degree of quadrature rule
-int degree = qr.Degree();
-
-// Get the order of a quadrature rule (degree + 1)
-int order = qr.Order();
-
-// Get points as columns of a matrix
-Eigen::MatrixXd points = qr.Points();
-
-// Get weights as a vector
-Eigen::VectorXd weights = qr.Weights();
-```
+@snippet{trimleft} quick_reference/qr_quad_snippets.cpp quad Using a Quadrature Rule
 

--- a/doc/doxygen/snippets/CMakeLists.txt
+++ b/doc/doxygen/snippets/CMakeLists.txt
@@ -1,5 +1,7 @@
 # Here we want to compile all snippets to make sure that they stay up-to-date, even when the code is refactored.
 
+add_subdirectory(quick_reference)
+
 set(sources
   assembler.cc
   coomatrix.cpp

--- a/doc/doxygen/snippets/quick_reference/CMakeLists.txt
+++ b/doc/doxygen/snippets/quick_reference/CMakeLists.txt
@@ -1,0 +1,16 @@
+# Here we want to compile all snippets to make sure that they stay up-to-date, even when the code is refactored.
+
+set(sources
+    qr_fe_space_snippets.cpp
+    qr_geometry_snippets.cpp
+    qr_quad_snippets.cpp
+    qr_mesh_snippets.cpp
+    qr_bc_snippets.cpp
+    qr_dofh_snippets.cpp
+    
+)
+
+add_library(docsnippets_qr ${sources})
+target_link_libraries(docsnippets_qr PUBLIC Eigen3::Eigen lf.base lf.mesh lf.geometry lf.assemble)
+set_target_properties(docsnippets_qr PROPERTIES FOLDER "doc")
+target_compile_features(docsnippets_qr PUBLIC cxx_std_17)

--- a/doc/doxygen/snippets/quick_reference/qr_bc_snippets.cpp
+++ b/doc/doxygen/snippets/quick_reference/qr_bc_snippets.cpp
@@ -1,0 +1,76 @@
+// This file contains Doxygen snippets for the quick reference bc document
+// It defines a function to hold all code snippets and includes necessary
+// imports.
+
+#include <lf/assemble/assemble.h>
+#include <lf/fe/fe.h>
+#include <lf/mesh/mesh.h>
+#include <lf/mesh/test_utils/test_meshes.h>
+#include <lf/uscalfe/uscalfe.h>
+
+#include <iostream>
+#include <memory>
+#include <utility>
+#include <vector>
+
+void qr_bc_snippets() {
+  {
+    auto mesh_p = lf::mesh::test_utils::GenerateHybrid2DTestMesh(0);
+    lf::assemble::UniformFEDofHandler dofh(mesh_p,
+                                           {{lf::base::RefEl::kPoint(), 1},
+                                            {lf::base::RefEl::kSegment(), 1},
+                                            {lf::base::RefEl::kTria(), 0},
+                                            {lf::base::RefEl::kQuad(), 1}});
+    {
+      //! [bc Overview]
+      lf::mesh::utils::CodimMeshDataSet<bool> bd_flags =
+          lf::mesh::utils::flagEntitiesOnBoundary(dofh.Mesh(), 2);
+      //! [bc Overview]
+    }
+
+    auto g = [](Eigen::Vector2d x) -> double { return x[0] + x[1]; };
+    auto fe_space =
+        std::make_shared<lf::uscalfe::FeSpaceLagrangeO1<double>>(mesh_p);
+    auto bd_flags =
+        lf::mesh::utils::flagEntitiesOnBoundary(fe_space->Mesh(), 1);
+    //! [bc One function on the whole boundary]
+    auto mf_g = lf::mesh::utils::MeshFunctionGlobal(g);
+
+    std::vector<std::pair<bool, double>> boundary_val =
+        lf::fe::InitEssentialConditionFromFunction(*fe_space, bd_flags, mf_g);
+    //! [bc One function on the whole boundary]
+
+    {
+      //! [bc One function on the whole boundary 0]
+      auto selector = [&](unsigned int dof_idx) -> std::pair<bool, double> {
+        return boundary_val[dof_idx];
+      };
+      //! [bc One function on the whole boundary 0]
+    }
+
+    //! [bc Constant value on the boundary]
+    auto selector = [&](unsigned int dof_idx) -> std::pair<bool, double> {
+      if (bd_flags(dofh.Entity(dof_idx))) {
+        return std::make_pair(true, 1.0);  // value 1.0 on the boundary
+      } else {
+        return std::make_pair(false, 0.0);  // value irrelevant
+      }
+    };
+    //! [bc Constant value on the boundary]
+
+    //! [bc BC only on part of the boundary]
+    lf::mesh::utils::AllCodimMeshDataSet<bool> bd_flags_part(mesh_p, false);
+    //! [bc BC only on part of the boundary]
+
+    bool condition = true;
+    //! [bc BC only on part of the boundary 0]
+    for (const auto& edge : fe_space->Mesh()->Entities(1)) {
+      if (condition) bd_flags_part(*edge) = true;
+    }
+
+    for (const auto& node : fe_space->Mesh()->Entities(2)) {
+      //...
+    }
+    //! [bc BC only on part of the boundary 0]
+  }
+}

--- a/doc/doxygen/snippets/quick_reference/qr_dofh_snippets.cpp
+++ b/doc/doxygen/snippets/quick_reference/qr_dofh_snippets.cpp
@@ -1,0 +1,74 @@
+// This file contains Doxygen snippets for the quick reference dofh document
+// It defines a function to hold all code snippets and includes necessary
+// imports.
+
+#include <lf/assemble/assemble.h>
+#include <lf/mesh/mesh.h>
+#include <lf/mesh/test_utils/test_meshes.h>
+
+#include <iostream>
+#include <memory>
+#include <span>
+
+void qr_dofh_snippets() {
+  {
+    //! [dofh DynamicFEDofHandler]
+    const std::shared_ptr<const lf::mesh::Mesh> mesh_p =
+        lf::mesh::test_utils::GenerateHybrid2DTestMesh(1);
+
+    auto func = [](const lf::mesh::Entity& e) {
+      // return number of dofs associated with e
+      return 1;
+    };
+
+    lf::assemble::DynamicFEDofHandler dofh(mesh_p, func);
+    //! [dofh DynamicFEDofHandler]
+  }
+
+  {
+    //! [dofh UniformFEDofHandler]
+    // Generate a simple test mesh
+    const std::shared_ptr<const lf::mesh::Mesh> mesh_p =
+        lf::mesh::test_utils::GenerateHybrid2DTestMesh(1);
+
+    // Initialize a DofHandler for p=2 Lagrange FE
+    lf::assemble::UniformFEDofHandler dofh(mesh_p,
+                                           {{lf::base::RefEl::kPoint(), 1},
+                                            {lf::base::RefEl::kSegment(), 1},
+                                            {lf::base::RefEl::kTria(), 0},
+                                            {lf::base::RefEl::kQuad(), 1}});
+    //! [dofh UniformFEDofHandler]
+
+    //! [dofh Key Methods]
+    unsigned num_dofs = dofh.NumDofs();
+    //! [dofh Key Methods]
+
+    {
+      //! [dofh Key Methods 0]
+      const lf::mesh::Entity* e = mesh_p->EntityByIndex(0, 0);
+
+      unsigned num_local_dofs = dofh.NumLocalDofs(*e);
+      //! [dofh Key Methods 0]
+    }
+
+    {
+      //! [dofh Key Methods 1]
+      const lf::mesh::Entity* e = mesh_p->EntityByIndex(0, 0);
+
+      std::span<const lf::assemble::gdof_idx_t> idx = dofh.GlobalDofIndices(*e);
+
+      for (auto i : idx) {
+        std::cout << i << " ";
+      }  // -> prints the global indices of DOFs associated with the entity
+      //! [dofh Key Methods 1]
+    }
+
+    {
+      //! [dofh Key Methods 2]
+      const lf::mesh::Entity* e = mesh_p->EntityByIndex(0, 0);
+
+      unsigned num_int_dofs = dofh.NumInteriorDofs(*e);
+      //! [dofh Key Methods 2]
+    }
+  }
+}

--- a/doc/doxygen/snippets/quick_reference/qr_fe_space_snippets.cpp
+++ b/doc/doxygen/snippets/quick_reference/qr_fe_space_snippets.cpp
@@ -1,0 +1,39 @@
+// This file contains Doxygen snippets for the quick reference fe_space document
+// It defines a function to hold all code snippets and includes necessary
+// imports.
+
+#include <iostream>
+#include <memory>
+
+#include "lf/fe/fe.h"
+#include "lf/mesh/test_utils/test_meshes.h"
+#include "lf/uscalfe/uscalfe.h"
+
+void qr_fe_space_snippets() {
+  {
+    //! [fe_space Hierarchic Scalar Finite Element Space]
+    // generate a simple test mesh
+    std::shared_ptr<lf::mesh::Mesh> mesh_p =
+        lf::mesh::test_utils::GenerateHybrid2DTestMesh(1);
+
+    // define a polynomial degree function
+    auto degree = [](const lf::mesh::Entity &entity) -> unsigned {
+      return 2;  // all entities have degree 2 -> equivalent to O2 Lagrangian
+                 // FESpace
+    };
+
+    // init HierarchicScalarFESpace on mesh_p
+    lf::fe::HierarchicScalarFESpace<double> fe_space(mesh_p, degree);
+    //! [fe_space Hierarchic Scalar Finite Element Space]
+  }
+  {
+    //! [fe_space Lagrangian Finite Element Spaces]
+    // generate a simple test mesh
+    std::shared_ptr<lf::mesh::Mesh> mesh_p =
+        lf::mesh::test_utils::GenerateHybrid2DTestMesh(1);
+
+    // init O1 Lagrangian finite element space on mesh_p
+    lf::uscalfe::FeSpaceLagrangeO1<double> fe_space(mesh_p);
+    //! [fe_space Lagrangian Finite Element Spaces]
+  }
+}

--- a/doc/doxygen/snippets/quick_reference/qr_geometry_snippets.cpp
+++ b/doc/doxygen/snippets/quick_reference/qr_geometry_snippets.cpp
@@ -1,0 +1,117 @@
+// This file contains Doxygen snippets for the quick reference geometry document
+// It defines a function to hold all code snippets and includes necessary
+// imports.
+
+#include <lf/geometry/geometry.h>
+#include <lf/mesh/mesh.h>
+#include <lf/mesh/test_utils/test_meshes.h>
+#include <lf/mesh/utils/utils.h>
+
+#include <iostream>
+
+void qr_geometry_snippets() {
+  const std::shared_ptr<const lf::mesh::Mesh> mesh_p =
+      lf::mesh::test_utils::GenerateHybrid2DTestMesh(1);
+  unsigned codim = 0;
+
+  {
+    //! [geometry Geometry Interface]
+    for (const lf::mesh::Entity* entity : mesh_p->Entities(codim)) {
+      // Get the geometry of an entity
+      const lf::geometry::Geometry* geometry = entity->Geometry();
+    }
+    //! [geometry Geometry Interface]
+  }
+
+  auto entity = mesh_p->EntityByIndex(0, 0);
+
+  {
+    //! [geometry Utility Functions]
+    const lf::geometry::Geometry* geometry = entity->Geometry();
+
+    // Get the volume of an entity (for edges length, for triangles area, etc.)
+    double v = lf::geometry::Volume(*geometry);
+
+    // Get the corners of an entity as a dxn matrix
+    // where d is the dimension of physical space, and n the number of corners.
+    // (for edges 2 corners, for triangles 3 corners, etc.)
+    Eigen::MatrixXd corners = lf::geometry::Corners(*geometry);
+    //! [geometry Utility Functions]
+
+    //! [geometry Utility Functions 0]
+    // Test if geometry is a non-degenerate bilinear quadrilateral (corners
+    // matrix with 4 cols)
+    bool is_not_deg_q = lf::geometry::assertNonDegenerateQuad(corners);
+
+    // Test if geometry is a non-degenerate triangle (corners matrix with 3
+    // cols)
+    bool is_not_deg_t = lf::geometry::assertNonDegenerateTriangle(corners);
+    //! [geometry Utility Functions 0]
+  }
+
+  auto geometry = entity->Geometry();
+
+  {
+    //! [geometry Geometry Methods]
+    // Dimension of the local coordinate system
+    unsigned dim_local = geometry->DimLocal();
+
+    // Dimension of the physical coordinate system
+    unsigned dim_global = geometry->DimGlobal();
+
+    // Get the reference element for the geometry
+    lf::base::RefEl ref_el = geometry->RefEl();
+
+    // Check if mapping is affine
+    bool is_affine = geometry->isAffine();
+    //! [geometry Geometry Methods]
+  }
+
+  {
+    //! [geometry Global]
+    // Define two point on the reference element (local).
+    Eigen::MatrixXd local_points(2, 2);
+    local_points << 0.1, 0.5, 0.6, 0.2;
+
+    // Map the points from the local into the global space.
+    Eigen::MatrixXd global = geometry->Global(local_points);
+    //! [geometry Global]
+
+    //! [geometry IntegrationElement]
+    // Compute the integration element for each point in points
+    Eigen::VectorXd integration_element =
+        geometry->IntegrationElement(local_points);
+    //! [geometry IntegrationElement]
+
+    //! [geometry Jacobian]
+    // Compute the Jacobian matrix for each point in points
+    Eigen::MatrixXd jacobian = geometry->Jacobian(local_points);
+    //! [geometry Jacobian]
+
+    unsigned n = 1;
+    //! [geometry Jacobian 0]
+    unsigned dim_global = geometry->DimGlobal();
+    unsigned dim_local = geometry->DimLocal();
+
+    // Access the Jacobian matrix for the n-th point (starting at 0)
+    Eigen::MatrixXd jacobian_n =
+        jacobian.block(0, n * dim_local, dim_global, dim_local);
+    //! [geometry Jacobian 0]
+
+    //! [geometry Jacobian 1]
+    // Access 2x2 Jacobian matrix starting at row 0 and column 2
+    Eigen::MatrixXd jacobian_2 = jacobian.block(0, 2, 2, 2);
+    //! [geometry Jacobian 1]
+
+    //! [geometry JacobianInverseGramian]
+    // Compute the inverse of the Jacobian matrix for each point in points
+    Eigen::MatrixXd jacobian_inv =
+        geometry->JacobianInverseGramian(local_points);
+
+    // Access the JacobianInverseGramian matrix for the n-th point (starting
+    // at 0)
+    Eigen::MatrixXd jacobian_inv_n =
+        jacobian_inv.block(0, n * dim_local, dim_global, dim_local);
+    //! [geometry JacobianInverseGramian]
+  }
+}

--- a/doc/doxygen/snippets/quick_reference/qr_mesh_snippets.cpp
+++ b/doc/doxygen/snippets/quick_reference/qr_mesh_snippets.cpp
@@ -1,0 +1,242 @@
+// This file contains Doxygen snippets for the quick reference mesh document
+// It defines a function to hold all code snippets and includes necessary
+// imports.
+
+#include <lf/io/io.h>
+#include <lf/mesh/mesh.h>
+#include <lf/mesh/test_utils/test_meshes.h>
+#include <lf/mesh/utils/utils.h>
+#include <lf/refinement/refinement.h>
+
+#include <iostream>
+#include <memory>
+#include <span>
+
+void qr_mesh_snippets() {
+  {
+    //! [mesh Overview]
+    // Generate a simple test mesh
+    const std::shared_ptr<const lf::mesh::Mesh> mesh_ptr =
+        lf::mesh::test_utils::GenerateHybrid2DTestMesh(1);
+
+    // Auto can be used to simplify the type declaration
+    auto mesh_ptr_auto = lf::mesh::test_utils::GenerateHybrid2DTestMesh(1);
+    //! [mesh Overview]
+  }
+
+  //! [mesh Mesh Access]
+  // create a pointer to the mesh
+  const std::shared_ptr<const lf::mesh::Mesh> mesh_p =
+      lf::mesh::test_utils::GenerateHybrid2DTestMesh(1);
+  //! [mesh Mesh Access]
+
+  {
+    //! [mesh Mesh Access 0]
+    // Access number of cells
+    unsigned num_entities = mesh_p->NumEntities(0);
+
+    // Access number of edges
+    unsigned num_nodes = mesh_p->NumEntities(1);
+
+    //! [mesh Mesh Access 0]
+  }
+
+  {
+    //! [mesh Entities]
+    // Get entity pointer by index from a mesh
+    const lf::mesh::Entity* entity = mesh_p->EntityByIndex(0, 0);
+
+    // Iterate over all entities of co-dimension 0 (cells)
+    for (const lf::mesh::Entity* cell : mesh_p->Entities(0)) {
+      // Do something with entity e.g.: print index of cell
+      std::cout << mesh_p->Index(*cell) << std::endl;
+    }
+    //! [mesh Entities]
+
+    //! [mesh Entities 0]
+    // Get the co-dimension of the entity
+    unsigned codim = entity->Codim();
+
+    // Get the geometry of the entity, more details can be found
+    // in the Geometry Quick reference
+    const lf::geometry::Geometry* geometry = entity->Geometry();
+
+    // Get the reference element of the entity (e.g. the unit triangle for a
+    // general triangle)
+    lf::base::RefEl ref_el = entity->RefEl();
+    //! [mesh Entities 0]
+
+    //! [mesh Entities 1]
+    // Return all sub entities of this entity that have the given
+    // co-dimension (w.r.t. this entity!)
+    // For example, for a cell, the sub-entities of co-dimension 1
+    std::span<const lf::mesh::Entity* const> sub_entities =
+        entity->SubEntities(1);
+
+    // If you require a vector of sub-entities, you can use the following code
+    // snippet
+    std::vector<const lf::mesh::Entity*> sub_entities_vec{
+        entity->SubEntities(1).begin(), entity->SubEntities(1).end()};
+
+    //! [mesh Entities 1]
+
+    //! [mesh Entities 2]
+    // return span of relative orientations of sub-entities of the next higher
+    // co-dimension.
+    std::span<const lf::mesh::Orientation> orientations =
+        entity->RelativeOrientations();
+
+    // If you require a vector of orientations, you can use the following code
+    // snippet
+    std::vector<lf::mesh::Orientation> orientations_vec{
+        entity->RelativeOrientations().begin(),
+        entity->RelativeOrientations().end()};
+    //! [mesh Entities 2]
+  }
+
+  {
+    //! [mesh Mesh Data Sets]
+    // Create a mesh data set storing boolean values for each entity
+    lf::mesh::utils::AllCodimMeshDataSet<bool> mesh_data_set =
+        lf::mesh::utils::AllCodimMeshDataSet<bool>(mesh_p);
+
+    // Create a MDS storing boolean values for each entity of co-dimension 1
+    // (edges)
+    lf::mesh::utils::CodimMeshDataSet<bool> mesh_data_set_edges =
+        lf::mesh::utils::CodimMeshDataSet<bool>(mesh_p, 1);
+
+    // Mesh data sets can be initialized with a default value
+    lf::mesh::utils::AllCodimMeshDataSet<bool> mesh_data_set_2 =
+        lf::mesh::utils::AllCodimMeshDataSet<bool>(mesh_p, false);
+
+    // Access a (modifiable) value associated with an entity
+    const lf::mesh::Entity* entity = mesh_p->EntityByIndex(0, 0);
+    bool value = mesh_data_set(*entity);
+    //! [mesh Mesh Data Sets]
+  }
+
+  {
+    //! [mesh Mesh Data Sets 0]
+    // Create MeshDataSet storing boolean values for each entity indicating if
+    // the entity is on the boundary
+    lf::mesh::utils::AllCodimMeshDataSet<bool> bd_flags{
+        lf::mesh::utils::flagEntitiesOnBoundary(mesh_p)};
+    //! [mesh Mesh Data Sets 0]
+  }
+
+  {
+    //! [mesh Mesh Functions]
+    // Define a lambda function that takes a point in the reference element of
+    // an entity and returns a value
+    auto alpha = [](Eigen::Vector2d x) -> double { return 0.5 * x.norm(); };
+
+    // Wrap the lambda function in a MeshFunctionGlobal object
+    // Type of mesh function template parameter is automatically deduced
+    lf::mesh::utils::MeshFunctionGlobal mesh_function =
+        lf::mesh::utils::MeshFunctionGlobal(alpha);
+
+    // Evaluate the mesh function on a cell
+    const lf::mesh::Entity* cell = mesh_p->EntityByIndex(0, 0);
+    std::vector<double> values =
+        mesh_function(*cell, Eigen::Vector2d{0.5, 0.5});
+
+    // We only asked for one point, so the vector has only one entry
+    std::cout << "Value: " << values[0] << std::endl;  // Value: 0.790569
+    //! [mesh Mesh Functions]
+  }
+
+  {
+    //! [mesh Mesh Creation]
+    // Generate a simple test mesh
+    std::shared_ptr<lf::mesh::Mesh> mesh_p =
+        lf::mesh::test_utils::GenerateHybrid2DTestMesh(1);
+    //! [mesh Mesh Creation]
+  }
+
+  {
+    //! [mesh Mesh Creation 0]
+    // Read a mesh from a file
+    std::unique_ptr<lf::mesh::hybrid2d::MeshFactory> mesh_factory =
+        std::make_unique<lf::mesh::hybrid2d::MeshFactory>(2);
+    lf::io::GmshReader gmsh_reader =
+        lf::io::GmshReader(std::move(mesh_factory), "triangle.msh");
+
+    // Get pointer to the mesh
+    std::shared_ptr<lf::mesh::Mesh> mesh = gmsh_reader.mesh();
+    //! [mesh Mesh Creation 0]
+  }
+
+  {
+    //! [mesh Mesh Refinement]
+    std::shared_ptr<lf::mesh::Mesh> mesh_p =
+        lf::mesh::test_utils::GenerateHybrid2DTestMesh(0);
+    // Generate mesh hierarchy by uniform refinement with 6 levels
+
+    std::shared_ptr<lf::refinement::MeshHierarchy> mesh_seq_p{
+        lf::refinement::GenerateMeshHierarchyByUniformRefinemnt(mesh_p, 3)};
+
+    // Access the mesh at level 3
+    std::shared_ptr<lf::mesh::Mesh> mesh_level_3 = mesh_seq_p->getMesh(3);
+
+    // We can refine a mesh further by calling
+    mesh_seq_p->RefineRegular();
+
+    // Access the mesh at level 4
+    std::shared_ptr<lf::mesh::Mesh> mesh_level_4 = mesh_seq_p->getMesh(4);
+    //! [mesh Mesh Refinement]
+  }
+
+  {
+    //! [mesh Mesh Builder]
+    // builder for a hybrid mesh in a world of dimension 2
+    std::shared_ptr<lf::mesh::hybrid2d::MeshFactory> mesh_factory =
+        std::make_shared<lf::mesh::hybrid2d::MeshFactory>(2);
+
+    // Add points (needs to be done before adding entities)
+    mesh_factory->AddPoint(Eigen::Vector2d{0, 0});    // (0)
+    mesh_factory->AddPoint(Eigen::Vector2d{1, 0});    // (1)
+    mesh_factory->AddPoint(Eigen::Vector2d{1, 1});    // (2)
+    mesh_factory->AddPoint(Eigen::Vector2d{0, 1});    // (3)
+    mesh_factory->AddPoint(Eigen::Vector2d{0.5, 1});  // (4)
+
+    // Add a triangle
+    // First set the coordinates of its nodes:
+    Eigen::MatrixXd nodesOfTria(2, 3);
+    nodesOfTria << 1, 1, 0.5, 0, 1, 1;
+    mesh_factory->AddEntity(
+        lf::base::RefEl::kTria(),  // we want a triangle
+        std::array<lf::mesh::Mesh::size_type, 3>{
+            {1, 2, 4}},  // indices of the nodes
+        std::make_unique<lf::geometry::TriaO1>(nodesOfTria));  // node coords
+
+    // Add a quadrilateral
+    Eigen::MatrixXd nodesOfQuad(2, 4);
+    nodesOfQuad << 0, 1, 0.5, 0, 0, 0, 1, 1;
+    mesh_factory->AddEntity(
+        lf::base::RefEl::kQuad(),  // we want a quadrilateral
+        std::array<lf::mesh::Mesh::size_type, 4>{
+            {0, 1, 4, 3}},  // indices of the nodes
+        std::make_unique<lf::geometry::QuadO1>(nodesOfQuad));  // node coords
+
+    // Build the mesh
+    std::shared_ptr<lf::mesh::Mesh> mesh = mesh_factory->Build();
+    //! [mesh Mesh Builder]
+  }
+
+  {
+    //! [mesh Mesh Builder 0]
+    // Create a LehrFEM++ square tensor product mesh
+    lf::mesh::utils::TPTriagMeshBuilder builder(
+        std::make_unique<lf::mesh::hybrid2d::MeshFactory>(2));
+
+    // Set mesh parameters following the builder pattern
+    // Domain is the unit square
+    builder.setBottomLeftCorner(Eigen::Vector2d{0, 0})
+        .setTopRightCorner(Eigen::Vector2d{99, 99})
+        .setNumXCells(100)
+        .setNumYCells(100);
+
+    std::shared_ptr<lf::mesh::Mesh> mesh_p = builder.Build();
+    //! [mesh Mesh Builder 0]
+  }
+}

--- a/doc/doxygen/snippets/quick_reference/qr_quad_snippets.cpp
+++ b/doc/doxygen/snippets/quick_reference/qr_quad_snippets.cpp
@@ -1,0 +1,60 @@
+// This file contains Doxygen snippets for the quick reference quad document
+// It defines a function to hold all code snippets and includes necessary
+// imports.
+
+#include <lf/base/base.h>
+#include <lf/quad/quad.h>
+
+#include <iostream>
+
+void qr_geometry_snippets() {
+  {
+    //! [quad Working with Quadrature Rules]
+    lf::base::RefEl ref_tria = lf::base::RefEl::kTria();
+
+    lf::quad::QuadRule qr = lf::quad::make_QuadRule(ref_tria, 3);
+    //! [quad Working with Quadrature Rules]
+  }
+
+  {
+    //! [quad Working with Quadrature Rules 0]
+    lf::base::RefEl ref_tria = lf::base::RefEl::kTria();
+
+    lf::quad::QuadRule qr = lf::quad::make_QuadRuleNodal(ref_tria);
+    //! [quad Working with Quadrature Rules 0]
+  }
+
+  {
+    //! [quad Working with Quadrature Rules 1]
+    lf::base::RefEl ref_tria = lf::base::RefEl::kTria();
+
+    Eigen::MatrixXd points(2, 3);
+    points << 0.166667, 0.666667, 0.166667, 0.166667, 0.166667, 0.666667;
+
+    Eigen::Vector3d weights;
+    weights << 0.166667, 0.166667, 0.166667;
+
+    lf::quad::QuadRule qr(ref_tria, points, weights, 2);
+    //! [quad Working with Quadrature Rules 1]
+  }
+
+  {
+    //! [quad Using a Quadrature Rule]
+    lf::base::RefEl ref_tria = lf::base::RefEl::kTria();
+
+    lf::quad::QuadRule qr = lf::quad::make_QuadRule(ref_tria, 3);
+
+    // Get degree of quadrature rule
+    int degree = qr.Degree();
+
+    // Get the order of a quadrature rule (degree + 1)
+    int order = qr.Order();
+
+    // Get points as columns of a matrix
+    Eigen::MatrixXd points = qr.Points();
+
+    // Get weights as a vector
+    Eigen::VectorXd weights = qr.Weights();
+    //! [quad Using a Quadrature Rule]
+  }
+}


### PR DESCRIPTION
Moved all cpp code snippets from the QR pages to `doc/doxygen/snippets/quick_reference/` so they can be checked at compile time.

Some examples had to be slightly tweaked due to conflicting names/scopes.